### PR TITLE
feat: Universal SKILL.md converter + Codex CLI bidirectional support (Tier A)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,6 +102,8 @@ jobs:
             exit 1
           fi
           echo "All examples valid"
+      - name: Validate Codex example with the conversion validator
+        run: bash scripts/validate-conversion.sh --target codex examples/codex-output
 
   installer-syntax:
     name: Validate Installer

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -16,5 +16,7 @@
   // Allow trailing punctuation in headings
   "MD026": false,
   // Nested example blocks don't always have a language
-  "MD040": false
+  "MD040": false,
+  // Table pipe spacing/alignment varies across our multi-column matrices
+  "MD060": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-05-29
+
+### Added
+
+- **Universal multi-format conversion.** The converter now targets five ecosystems in any direction: Claude Code, Deep Agents CLI, Codex CLI, Qwen Code, and Cursor.
+- **Cross-format reference matrix** in `SKILL.en.md` / `SKILL.pt.md` mapping skill paths, frontmatter fields, memory files, tool names, MCP config, and command arguments across all five formats.
+- **Source/target format detection** via fingerprints, and a **two-tier model**: Tier A (light remap for the natural-language SKILL.md targets — Codex/Qwen/Cursor) and Tier B (the existing heavy Claude Code ↔ Deep Agents T1–T8 translation).
+- **Codex CLI converter** (bidirectional), verified against Codex CLI 0.98.0: `$CODEX_HOME/skills` layout, strict frontmatter allow-list (`name`, `description`, `license`, `allowed-tools`, `metadata`), and the no-`<`/`>`-in-description rule.
+- `examples/codex-output/SKILL.md` — full before/after of the FastAPI Todo sample converted to Codex format (passes Codex's bundled `quick_validate.py`).
+- `scripts/validate-conversion.sh` — dependency-light, multi-target conversion validator (Codex rules implemented; Cursor/Qwen/Deep Agents/Claude targets scaffolded). Wired into CI.
+
+### Changed
+
+- Skill renamed in spirit to **Universal SKILL.md Converter** (skill `name` stays `skill-converter` for install compatibility); `converter-version` bumped to `2.2`.
+- `.github/workflows/lint.yml` now validates the Codex example with `validate-conversion.sh`.
+- Golden Rules reorganized into Universal rules + Tier B additions.
+
 ## [2.1.0] - 2026-04-02
 
 ### Added
@@ -69,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Complete documentation in English (`README.en.md`, `SKILL.en.md`)
 - Complete documentation in Portuguese (`README.pt.md`, `SKILL.pt.md`)
 
+[2.2.0]: https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter/releases/tag/v2.2.0
 [2.1.0]: https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter/releases/tag/v2.1.0
 [2.0.0]: https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter/releases/tag/v2.0.0
 [1.0.0]: https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude Code ↔ Deep Agents Skill Converter
+# Universal SKILL.md Converter — Claude Code · Deep Agents · Codex · Qwen Code · Cursor
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Lint & Validate](https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter/actions/workflows/lint.yml/badge.svg)](https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter/actions/workflows/lint.yml)
@@ -8,20 +8,44 @@
 [![Installs](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fandersonamaral2%2FClaude-Code-to-Deep-Agents-Skills-Converter%2Finstall&count_bg=%2379C83D&title_bg=%23555555&icon=&emoji=&title=installs&edge_flat=false)](https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter)
 [![Visitors](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fandersonamaral2%2FClaude-Code-to-Deep-Agents-Skills-Converter&count_bg=%230969DA&title_bg=%23555555&icon=&emoji=&title=visitors&edge_flat=false)](https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter)
 
-Convert **any** SKILL.md between Claude Code and Deep Agents CLI formats — preserving 100% of the domain knowledge while adapting the execution interface. Now with bidirectional conversion, dry-run preview, and batch processing.
+Convert **any** SKILL.md between **Claude Code, Deep Agents CLI, Codex CLI, Qwen Code, and Cursor** — preserving 100% of the domain knowledge while adapting each target's execution interface. Every direction is supported, plus dry-run preview and batch processing.
 
 > **Portugues?** [Leia em Portugues](/README.pt.md)
+
+## Supported formats
+
+| Format | User-level skill dir | Conversion tier |
+|--------|----------------------|-----------------|
+| **Claude Code** | `~/.claude/skills/<name>/SKILL.md` | — (hub format) |
+| **Deep Agents CLI** | `~/.deepagents/agent/skills/<name>/SKILL.md` | Tier B (typed tools) |
+| **Codex CLI** | `~/.codex/skills/<name>/SKILL.md` | Tier A (light remap) |
+| **Qwen Code** | `~/.qwen/skills/<name>/SKILL.md` | Tier A (light remap) |
+| **Cursor** | `~/.cursor/skills/<name>/SKILL.md` | Tier A (light remap) |
+
+All five now use a near-identical natural-language `SKILL.md` format, so conversion to Codex,
+Qwen Code, and Cursor is mostly **frontmatter + path + MCP-config remapping** (Tier A). Deep
+Agents uses typed explicit tools (`write_file`, `execute`, `task`), so it gets the heavier
+**Tier B** translation. The full mapping lives in the
+[cross-format reference matrix](/SKILL.en.md#cross-format-reference-matrix) inside the skill.
 
 ---
 
 ## Why does this exist?
 
-Claude Code and Deep Agents CLI are both agents with filesystem and shell access, but they speak different "languages":
+Coding agents increasingly share the same `SKILL.md` idea — a folder with a `SKILL.md` that
+teaches the agent a procedure — but they differ in the details that make a skill actually load
+and run:
 
-- **Claude Code** operates with implicit bash — it simply "writes" files and "runs" commands without declaring which tool it's using.
-- **Deep Agents CLI** operates with typed, explicit tools — `write_file`, `execute`, `edit_file`, `task`, etc.
+- **Frontmatter rules** differ (Codex forbids `<`/`>` in the description and allows only five
+  keys; Qwen uses `allowedTools` in camelCase; Cursor skills use `paths`).
+- **File locations** differ (`~/.codex/skills`, `~/.qwen/skills`, `~/.cursor/skills`, …).
+- **Memory files** differ (`CLAUDE.md` vs `AGENTS.md` vs `QWEN.md`).
+- **Deep Agents** goes further: it uses typed, explicit tools (`write_file`, `execute`,
+  `task`), so implicit "create file X" must become "use `write_file` to create X".
 
-A skill that works perfectly in Claude Code **won't work** in Deep Agents because the agent can't translate "create file X" into "use the `write_file` tool to create X". This converter handles that translation automatically — in both directions.
+A skill authored for one tool won't cleanly load in another until those details are remapped.
+This converter handles that translation automatically — **in every direction** — preserving
+100% of the domain knowledge.
 
 ---
 
@@ -152,6 +176,25 @@ deepagents -y
 > Convert this Deep Agents skill back to Claude Code format:
 > Read ~/deepagents-skills/my-skill/SKILL.md and convert to Claude Code.
 > Save as my-skill-claude-code/SKILL.md
+```
+
+### Method 2b — Convert Claude Code → Codex (Tier A)
+
+```bash
+deepagents -y
+
+> Read ~/.claude/skills/my-skill/SKILL.md and convert it to Codex format.
+> Save as ~/.codex/skills/my-skill/SKILL.md
+```
+
+The converter keeps the instruction prose, adds Codex-valid frontmatter (hyphen-case `name`,
+`description` with no `<`/`>`), and remaps `CLAUDE.md` → `AGENTS.md`. Validate the result with:
+
+```bash
+# the converter's own validator
+scripts/validate-conversion.sh --target codex ~/.codex/skills/my-skill
+# and Codex's bundled validator, if installed
+python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py ~/.codex/skills/my-skill
 ```
 
 ### Method 3 — Dry-run / Preview (no save)

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,19 +1,43 @@
-# Claude Code ↔ Deep Agents Skill Converter
+# Conversor Universal de SKILL.md — Claude Code · Deep Agents · Codex · Qwen Code · Cursor
 
-Converte **qualquer** SKILL.md entre os formatos Claude Code e Deep Agents CLI — preservando 100% do conhecimento de domínio e adaptando a interface de execução. Agora com conversão bidirecional, preview dry-run e processamento em lote.
+Converte **qualquer** SKILL.md entre **Claude Code, Deep Agents CLI, Codex CLI, Qwen Code e Cursor** — preservando 100% do conhecimento de domínio e adaptando a interface de execução de cada alvo. Todas as direções são suportadas, além de preview dry-run e processamento em lote.
 
 > **English?** [Read in English](/README.md)
+
+## Formatos suportados
+
+| Formato | Dir. de skills (usuário) | Tier de conversão |
+|---------|--------------------------|-------------------|
+| **Claude Code** | `~/.claude/skills/<nome>/SKILL.md` | — (formato hub) |
+| **Deep Agents CLI** | `~/.deepagents/agent/skills/<nome>/SKILL.md` | Tier B (ferramentas tipadas) |
+| **Codex CLI** | `~/.codex/skills/<nome>/SKILL.md` | Tier A (remap leve) |
+| **Qwen Code** | `~/.qwen/skills/<nome>/SKILL.md` | Tier A (remap leve) |
+| **Cursor** | `~/.cursor/skills/<nome>/SKILL.md` | Tier A (remap leve) |
+
+Os cinco agora usam um formato `SKILL.md` em linguagem natural quase idêntico, então converter
+para Codex, Qwen Code e Cursor é basicamente **remapear frontmatter + caminhos + config MCP**
+(Tier A). O Deep Agents usa ferramentas tipadas e explícitas (`write_file`, `execute`, `task`),
+então recebe a tradução mais pesada (**Tier B**). O mapeamento completo está na
+[matriz de referência entre formatos](/SKILL.pt.md#matriz-de-referência-entre-formatos) dentro da skill.
 
 ---
 
 ## Por que isso existe?
 
-O Claude Code e o Deep Agents CLI são ambos agentes com acesso a filesystem e shell, mas falam "línguas" diferentes:
+Agentes de código compartilham cada vez mais a mesma ideia de `SKILL.md` — uma pasta com um
+`SKILL.md` que ensina um procedimento ao agente — mas diferem nos detalhes que fazem a skill
+realmente carregar e rodar:
 
-- **Claude Code** opera com bash implícito — ele simplesmente "escreve" arquivos e "roda" comandos sem precisar declarar qual tool está usando.
-- **Deep Agents CLI** opera com tools tipadas e explícitas — `write_file`, `execute`, `edit_file`, `task`, etc.
+- **Regras de frontmatter** diferem (o Codex proíbe `<`/`>` na description e só aceita cinco
+  chaves; o Qwen usa `allowedTools` em camelCase; skills do Cursor usam `paths`).
+- **Locais dos arquivos** diferem (`~/.codex/skills`, `~/.qwen/skills`, `~/.cursor/skills`, …).
+- **Arquivos de memória** diferem (`CLAUDE.md` vs `AGENTS.md` vs `QWEN.md`).
+- **Deep Agents** vai além: usa ferramentas tipadas e explícitas (`write_file`, `execute`,
+  `task`), então "crie o arquivo X" implícito precisa virar "use `write_file` para criar X".
 
-Uma skill perfeita para o Claude Code **não funciona** no Deep Agents porque o agente não sabe traduzir "crie o arquivo X" para "use a tool `write_file` para criar X". Este conversor faz essa tradução automaticamente — nas duas direções.
+Uma skill feita para uma ferramenta não carrega direito em outra até esses detalhes serem
+remapeados. Este conversor faz essa tradução automaticamente — **em todas as direções** —
+preservando 100% do conhecimento de domínio.
 
 ---
 
@@ -142,6 +166,25 @@ deepagents -y
 > Converta essa skill do Deep Agents de volta para o formato Claude Code:
 > Leia ~/deepagents-skills/minha-skill/SKILL.md e converta para Claude Code.
 > Salve como minha-skill-claude-code/SKILL.md
+```
+
+### Método 2b — Converter Claude Code → Codex (Tier A)
+
+```bash
+deepagents -y
+
+> Leia ~/.claude/skills/minha-skill/SKILL.md e converta para o formato Codex.
+> Salve como ~/.codex/skills/minha-skill/SKILL.md
+```
+
+O conversor mantém a prosa das instruções, adiciona frontmatter válido para Codex (`name` em
+hyphen-case, `description` sem `<`/`>`) e remapeia `CLAUDE.md` → `AGENTS.md`. Valide o resultado com:
+
+```bash
+# o validador do próprio conversor
+scripts/validate-conversion.sh --target codex ~/.codex/skills/minha-skill
+# e o validador que vem com o Codex, se instalado
+python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py ~/.codex/skills/minha-skill
 ```
 
 ### Método 3 — Dry-run / Preview (sem salvar)

--- a/SKILL.en.md
+++ b/SKILL.en.md
@@ -1,15 +1,16 @@
 ---
 name: skill-converter
-description: "Converts any SKILL.md between Claude Code and Deep Agents CLI formats — preserving 100% of domain knowledge while adapting the execution interface. Supports forward, reverse, dry-run, and batch conversion."
+description: "Universal SKILL.md converter between Claude Code, Deep Agents CLI, Codex CLI, Qwen Code, and Cursor — preserving 100% of domain knowledge while adapting each target's execution interface. Bidirectional, with dry-run preview and batch processing."
 metadata:
-  converter-version: "2.0"
+  converter-version: "2.2"
   deep-agents-compat: ">=0.0.34"
+  codex-compat: ">=0.98.0"
   source-repo: "https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter"
 ---
 
-# Skill: Claude Code ↔ Deep Agents Skill Converter
+# Skill: Universal SKILL.md Converter
 
-> Converts any SKILL.md between Claude Code and Deep Agents CLI formats — preserving 100% of domain knowledge while adapting the execution interface. Supports forward conversion (Claude Code → Deep Agents), reverse conversion (Deep Agents → Claude Code), dry-run preview, and batch processing.
+> Converts any SKILL.md between Claude Code, Deep Agents CLI, Codex CLI, Qwen Code, and Cursor — preserving 100% of domain knowledge while adapting each target's execution interface. Every direction is supported, plus dry-run preview and batch processing.
 
 ---
 
@@ -17,16 +18,147 @@ metadata:
 
 This skill is triggered when the user asks something like:
 
-- "Convert this Claude Code skill to Deep Agents"
-- "Convert this Deep Agents skill to Claude Code"
-- "Adapt this SKILL.md to work with Deep Agents"
-- "Port this skill from Claude Code to Deep Agents"
-- "I have a Claude Code skill, I want to use it in Deep Agents"
+- "Convert this Claude Code skill to Deep Agents / Codex / Qwen Code / Cursor"
+- "Convert this Codex (or Qwen / Cursor / Deep Agents) skill back to Claude Code"
+- "Adapt this SKILL.md to work with {tool}"
+- "Port / migrate this skill from {tool A} to {tool B}"
+- "I have a skill for {tool A}, I want to use it in {tool B}"
 - "Preview the conversion without saving" / "Dry-run"
 - "Convert all skills in this folder"
 - Or when the user provides a SKILL.md file and asks to "convert", "adapt", "port", "migrate"
 
 ---
+
+## Supported formats
+
+This converter handles five agent-skill ecosystems, in **any** direction:
+
+| Format | User-level skill dir | Skill body style |
+|--------|----------------------|------------------|
+| **Claude Code** | `~/.claude/skills/<name>/SKILL.md` | Natural language, implicit tools |
+| **Deep Agents CLI** | `~/.deepagents/agent/skills/<name>/SKILL.md` | Typed explicit tools (`write_file`, `execute`, `task`) |
+| **Codex CLI** | `~/.codex/skills/<name>/SKILL.md` (`$CODEX_HOME/skills`) | Natural language, implicit `shell`/`apply_patch` |
+| **Qwen Code** | `~/.qwen/skills/<name>/SKILL.md` | Natural language; tools are snake_case |
+| **Cursor** | `~/.cursor/skills/<name>/SKILL.md` | Natural language; also reads `.claude/skills/` as legacy |
+
+> **Verified locally:** Codex CLI 0.98.0 discovers skills under `$CODEX_HOME/skills` and
+> validates frontmatter with `skill-creator/scripts/quick_validate.py`. Newer/older versions
+> and project-level paths may differ — always confirm against the installed CLI.
+
+---
+
+## Cross-format reference matrix
+
+This table is the heart of the converter. To convert, look up the **source** column and the
+**target** column for each concept and remap accordingly.
+
+| Concept | Claude Code | Deep Agents CLI | Codex CLI | Qwen Code | Cursor |
+|---------|-------------|-----------------|-----------|-----------|--------|
+| Skill dir (user) | `~/.claude/skills/` | `~/.deepagents/agent/skills/` | `~/.codex/skills/` | `~/.qwen/skills/` | `~/.cursor/skills/` |
+| Skill dir (project) | `.claude/skills/` | `.deepagents/skills/` | `.codex/skills/` | `.qwen/skills/` | `.cursor/skills/` (+ reads `.claude/skills/`) |
+| Frontmatter required | `name`, `description` | `name`, `description` | `name`, `description` | `name`, `description` | `name`, `description` |
+| Frontmatter optional | `allowed-tools` | `metadata` | `license`, `allowed-tools`, `metadata` | `allowedTools`, `argument-hint`, `priority`, `paths`, `disable-model-invocation` | `paths`, `disable-model-invocation`, `metadata` |
+| `name` rules | hyphen-case | hyphen-case | hyphen-case, ≤64 chars | unicode-aware slug | lowercase + hyphens |
+| `description` rules | ≤1024 | ≤1024 | ≤1024, **no `<` or `>`** | ≤1024 | ≤1024 |
+| Memory / context file | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` (+ `AGENTS.override.md`) | `QWEN.md` (also `AGENTS.md`) | `.cursor/rules/*.mdc` (Always) or `AGENTS.md` |
+| Slash commands | `.claude/commands/*.md` | (n/a) | `~/.codex/prompts/*.md` (deprecated) | `.qwen/commands/*.md` | `.cursor/commands/*.md` |
+| Command arguments | `$ARGUMENTS`, `$1` | (n/a) | `$1`–`$9`, `$ARGUMENTS` | `{{args}}` | (n/a) |
+| Create / edit file | implicit | `write_file` / `edit_file` | implicit (`apply_patch`) | `write_file` / `edit` / `replace` | implicit (agent) |
+| Run shell | implicit `bash` | `execute` | implicit `shell` | `run_shell_command` | terminal (with approval) |
+| Read / search | implicit | `read_file` / `grep` / `glob` | implicit | `read_file` / `grep` / `glob` | implicit |
+| Sub-agents | `Agent` / `Task` | `task` | (none at skill level) | `task` / subagents | **none (non-portable)** |
+| Config file | `settings.json` | (CLI config) | `config.toml` | `settings.json` | settings + `.cursor/mcp.json` |
+| MCP config | `.mcp.json` (`mcpServers`) | `.deepagents/mcp.json` | `[mcp_servers.*]` in `config.toml` | `mcpServers` in `settings.json` | `.cursor/mcp.json` (`mcpServers`) |
+
+---
+
+## Detect the source and target format
+
+If the user does not state both ends explicitly, infer them from these fingerprints:
+
+- **Deep Agents** — explicit `write_file`, `edit_file`, `execute`, `write_todos`, `task`
+  tool references; `.deepagents/`; "Execution Context"/"Execution Plan" sections.
+- **Codex** — `apply_patch`, `shell` tool, `~/.codex/skills` / `.codex/`, `config.toml`,
+  `AGENTS.md`; frontmatter limited to `name`/`description`/`license`/`allowed-tools`/`metadata`.
+- **Qwen Code** — `allowedTools:` (camelCase key) with snake_case tool names, `.qwen/`,
+  `QWEN.md`, `{{args}}` in commands.
+- **Cursor** — `.cursor/skills` / `.cursor/rules/*.mdc`, `globs`/`alwaysApply` frontmatter
+  (that is a Rule, not a Skill).
+- **Claude Code** — natural-language instructions with no explicit tool names, `CLAUDE.md`,
+  `.claude/`, `$ARGUMENTS`/`$1`; often **no frontmatter at all**.
+
+---
+
+## Two conversion tiers
+
+The amount of work depends on the pair:
+
+- **Tier A — light remap** (Claude Code ↔ Codex / Qwen / Cursor). All four are
+  *natural-language* `SKILL.md` formats with near-identical structure. Conversion is mostly
+  frontmatter + path/memory-file remapping; the instruction prose stays essentially the same.
+  See **Tier A procedure** below.
+- **Tier B — heavy translation** (Claude Code ↔ Deep Agents). Deep Agents uses *typed,
+  explicit* tools, so implicit "create the file" must become explicit `write_file`, etc. This
+  is the full T1–T8 procedure documented from **Context: Why conversion is needed** onward.
+
+> Converting between two non-Claude formats (e.g. Codex → Cursor)? Route through Claude Code
+> as the neutral hub: source → Claude Code → target. In practice, for Tier-A pairs you can
+> remap directly using the matrix.
+
+---
+
+## Tier A procedure (SKILL.md ↔ SKILL.md: Codex, Qwen Code, Cursor)
+
+These targets run natural-language skills almost identically to Claude Code, so the domain
+content and step prose are preserved verbatim. Only the *envelope* changes.
+
+1. **Read the source skill** and detect source + target (see fingerprints above).
+2. **Frontmatter:**
+   - Ensure a `name` exists and is **hyphen-case** (`^[a-z0-9-]+$`, no leading/trailing
+     hyphen, no `--`, ≤64 chars). Claude Code skills often have *no frontmatter* — derive the
+     name from the folder or the `# Skill:` title.
+   - Ensure a `description` exists (≤1024 chars) that states **what it does and when to use
+     it** (targets use it for auto-invocation).
+   - Remap optional fields per the matrix:
+     - Claude `allowed-tools` ⇄ Codex `allowed-tools` (same key) ⇄ Qwen `allowedTools`
+       (camelCase key, **snake_case tool names**). Cursor skills don't use an allow-list — drop it.
+     - Keep `metadata` where supported (Claude/Codex/Cursor); add a
+       `converted-from`/`converter-version` stamp.
+3. **Body remap** (light — preserve all domain knowledge, code, tables):
+   - Memory/context file: `CLAUDE.md` → target's (`AGENTS.md` for Codex, `QWEN.md` for Qwen,
+     `AGENTS.md`/Rules for Cursor) and vice versa.
+   - Path references: `.claude/` → the target's skill/config dir.
+   - MCP config: remap path **and format** per the matrix (`.mcp.json` JSON →
+     `config.toml [mcp_servers]` for Codex; → `settings.json mcpServers` for Qwen; →
+     `.cursor/mcp.json` for Cursor).
+4. **Flag non-portable features explicitly** (never drop silently — add a note):
+   - Sub-agents/`Task` → **Cursor has no skill-level sub-agents**; Codex/Qwen keep `task`.
+   - Claude Code hooks (`settings.json`) → no skill equivalent; document as manual/CI steps.
+   - Extended thinking → model-dependent; remove tool-specific config, keep the intent.
+5. **Validate** with `scripts/validate-conversion.sh --target <codex|cursor|qwen> <dir>`
+   (and, for Codex, the bundled `skill-creator/scripts/quick_validate.py`).
+6. **Save** to `<name>/SKILL.md` under the target's skill dir (see matrix).
+
+### Codex specifics (verified against Codex CLI 0.98.0)
+
+- Frontmatter **allow-list is strict**: only `name`, `description`, `license`,
+  `allowed-tools`, `metadata`. Any other top-level key fails `quick_validate.py`.
+- `description` **must not contain `<` or `>`** — rewrite phrasings like "when A > B" to
+  "when A is greater than B". This is the most common Claude → Codex breakage.
+- Optional `agents/openai.yaml` sidecar provides UI metadata
+  (`interface.display_name`, `short_description`, icons). Generate it only if the user wants
+  the skill to show a custom label/icon.
+- Optional `scripts/`, `references/`, `assets/` subdirectories are copied as-is.
+- See `examples/claude-code-sample/SKILL.md` → `examples/codex-output/SKILL.md` for a full
+  before/after.
+
+---
+
+# Tier B — Claude Code ↔ Deep Agents (heavy translation)
+
+Everything from here on is the **Deep Agents** path: the implicit↔explicit tool translation
+(T1–T8). For Codex, Qwen Code, and Cursor, use the **Tier A procedure** above instead — those
+targets do not need this level of rewriting.
 
 ## Context: Why conversion is needed
 
@@ -1288,13 +1420,18 @@ Sections 7–11 vary per skill. The important thing is that ALL technical sectio
 
 ## Golden Rules
 
-1. **Never lose content.** The converted skill is ≥ original size.
-2. **Never assume implicits.** Deep Agents CLI needs explicit instructions on which tool to use.
-3. **Always start with `write_todos`.** The plan is the foundation of every Deep Agents execution.
-4. **Test after every `write_file`.** The create → test → next pattern is unbreakable.
-5. **Use `task` for parallelism.** If the skill processes N items, use N sub-agents.
-6. **Preserve all domain knowledge.** Tables, regex, formulas, templates — everything.
-7. **Catch inline commands.** Backtick-wrapped commands inside sentences need conversion too.
-8. **Handle env vars explicitly.** Never assume variables are available — verify or document them.
-9. **Make conditionals executable.** Platform checks become shell `case`/`if` blocks, not prose.
-10. **Validate with the checklist.** Run the grep-based validation before saving.
+**Universal (every target):**
+
+1. **Preserve all domain knowledge.** Tables, regex, formulas, code, templates — everything. The converted skill is ≥ the original in technical content.
+2. **Pick the right tier.** Codex / Qwen / Cursor → Tier A (light remap). Deep Agents → Tier B (T1–T8).
+3. **Remap the envelope, not the meaning.** Frontmatter, paths, memory file, MCP config — per the cross-format matrix.
+4. **Respect each target's frontmatter rules.** Hyphen-case `name` ≤64; `description` ≤1024; for Codex, no `<`/`>` in the description and only the five allowed keys.
+5. **Flag non-portable features — never drop silently.** Sub-agents into Cursor, hooks, extended thinking: leave a note.
+6. **Validate before saving.** Run `scripts/validate-conversion.sh --target <t>` (and Codex's `quick_validate.py` for Codex).
+
+**Tier B (Deep Agents) additions:**
+
+7. **Never assume implicits.** Deep Agents needs explicit instructions on which tool to use.
+8. **Always start with `write_todos`** and **test after every `write_file`** (create → test → next).
+9. **Use `task` for parallelism**, handle **env vars explicitly**, and make **conditionals executable** (`case`/`if`).
+10. **Catch inline commands.** Backtick-wrapped commands inside sentences need conversion too.

--- a/SKILL.pt.md
+++ b/SKILL.pt.md
@@ -1,15 +1,16 @@
 ---
 name: skill-converter
-description: "Converte qualquer SKILL.md entre os formatos Claude Code e Deep Agents CLI — preservando 100% do conhecimento de dominio e adaptando a interface de execucao. Suporta conversao direta, reversa, dry-run e batch."
+description: "Conversor universal de SKILL.md entre Claude Code, Deep Agents CLI, Codex CLI, Qwen Code e Cursor — preservando 100% do conhecimento de dominio e adaptando a interface de execucao de cada alvo. Bidirecional, com preview dry-run e processamento em lote."
 metadata:
-  converter-version: "2.0"
+  converter-version: "2.2"
   deep-agents-compat: ">=0.0.34"
+  codex-compat: ">=0.98.0"
   source-repo: "https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter"
 ---
 
-# Skill: Claude Code ↔ Deep Agents Skill Converter
+# Skill: Conversor Universal de SKILL.md
 
-> Converte qualquer SKILL.md entre os formatos Claude Code e Deep Agents CLI — preservando 100% do conhecimento de domínio e adaptando a interface de execução. Suporta conversão direta (Claude Code → Deep Agents), conversão reversa (Deep Agents → Claude Code), preview dry-run e processamento em lote.
+> Converte qualquer SKILL.md entre Claude Code, Deep Agents CLI, Codex CLI, Qwen Code e Cursor — preservando 100% do conhecimento de domínio e adaptando a interface de execução de cada alvo. Todas as direções são suportadas, além de preview dry-run e processamento em lote.
 
 ---
 
@@ -17,16 +18,149 @@ metadata:
 
 Esta skill é ativada quando o usuário pedir algo como:
 
-- "Converta essa skill do Claude Code para Deep Agents"
-- "Converta essa skill do Deep Agents para Claude Code"
-- "Adapte esse SKILL.md para funcionar no Deep Agents"
-- "Transforme essa skill de Claude Code em Deep Agents"
-- "Tenho uma skill do Claude Code, quero usar no Deep Agents"
+- "Converta essa skill do Claude Code para Deep Agents / Codex / Qwen Code / Cursor"
+- "Converta essa skill do Codex (ou Qwen / Cursor / Deep Agents) de volta para Claude Code"
+- "Adapte esse SKILL.md para funcionar no {ferramenta}"
+- "Porte / migre essa skill de {ferramenta A} para {ferramenta B}"
+- "Tenho uma skill para {ferramenta A}, quero usar no {ferramenta B}"
 - "Mostre o preview da conversão sem salvar" / "Dry-run"
 - "Converta todas as skills nessa pasta"
 - Ou quando o usuário fornecer um arquivo SKILL.md e pedir para "converter", "adaptar", "portar", "migrar"
 
 ---
+
+## Formatos suportados
+
+Este conversor lida com cinco ecossistemas de agent-skills, em **qualquer** direção:
+
+| Formato | Dir. de skills (usuário) | Estilo do corpo da skill |
+|---------|--------------------------|--------------------------|
+| **Claude Code** | `~/.claude/skills/<nome>/SKILL.md` | Linguagem natural, ferramentas implícitas |
+| **Deep Agents CLI** | `~/.deepagents/agent/skills/<nome>/SKILL.md` | Ferramentas tipadas explícitas (`write_file`, `execute`, `task`) |
+| **Codex CLI** | `~/.codex/skills/<nome>/SKILL.md` (`$CODEX_HOME/skills`) | Linguagem natural, `shell`/`apply_patch` implícitos |
+| **Qwen Code** | `~/.qwen/skills/<nome>/SKILL.md` | Linguagem natural; ferramentas em snake_case |
+| **Cursor** | `~/.cursor/skills/<nome>/SKILL.md` | Linguagem natural; também lê `.claude/skills/` como legado |
+
+> **Verificado localmente:** o Codex CLI 0.98.0 descobre skills em `$CODEX_HOME/skills` e
+> valida o frontmatter com `skill-creator/scripts/quick_validate.py`. Versões diferentes e
+> caminhos a nível de projeto podem variar — sempre confirme na CLI instalada.
+
+---
+
+## Matriz de referência entre formatos
+
+Esta tabela é o coração do conversor. Para converter, consulte a coluna de **origem** e a
+coluna de **destino** de cada conceito e faça o remapeamento correspondente.
+
+| Conceito | Claude Code | Deep Agents CLI | Codex CLI | Qwen Code | Cursor |
+|----------|-------------|-----------------|-----------|-----------|--------|
+| Dir. skills (usuário) | `~/.claude/skills/` | `~/.deepagents/agent/skills/` | `~/.codex/skills/` | `~/.qwen/skills/` | `~/.cursor/skills/` |
+| Dir. skills (projeto) | `.claude/skills/` | `.deepagents/skills/` | `.codex/skills/` | `.qwen/skills/` | `.cursor/skills/` (+ lê `.claude/skills/`) |
+| Frontmatter obrigatório | `name`, `description` | `name`, `description` | `name`, `description` | `name`, `description` | `name`, `description` |
+| Frontmatter opcional | `allowed-tools` | `metadata` | `license`, `allowed-tools`, `metadata` | `allowedTools`, `argument-hint`, `priority`, `paths`, `disable-model-invocation` | `paths`, `disable-model-invocation`, `metadata` |
+| Regras de `name` | hyphen-case | hyphen-case | hyphen-case, ≤64 chars | slug com unicode | minúsculas + hífens |
+| Regras de `description` | ≤1024 | ≤1024 | ≤1024, **sem `<` ou `>`** | ≤1024 | ≤1024 |
+| Arquivo de memória/contexto | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` (+ `AGENTS.override.md`) | `QWEN.md` (também `AGENTS.md`) | `.cursor/rules/*.mdc` (Always) ou `AGENTS.md` |
+| Slash commands | `.claude/commands/*.md` | (n/d) | `~/.codex/prompts/*.md` (descontinuado) | `.qwen/commands/*.md` | `.cursor/commands/*.md` |
+| Argumentos de comando | `$ARGUMENTS`, `$1` | (n/d) | `$1`–`$9`, `$ARGUMENTS` | `{{args}}` | (n/d) |
+| Criar / editar arquivo | implícito | `write_file` / `edit_file` | implícito (`apply_patch`) | `write_file` / `edit` / `replace` | implícito (agente) |
+| Rodar shell | `bash` implícito | `execute` | `shell` implícito | `run_shell_command` | terminal (com aprovação) |
+| Ler / buscar | implícito | `read_file` / `grep` / `glob` | implícito | `read_file` / `grep` / `glob` | implícito |
+| Sub-agentes | `Agent` / `Task` | `task` | (nenhum a nível de skill) | `task` / subagents | **nenhum (não portável)** |
+| Arquivo de config | `settings.json` | (config da CLI) | `config.toml` | `settings.json` | settings + `.cursor/mcp.json` |
+| Config MCP | `.mcp.json` (`mcpServers`) | `.deepagents/mcp.json` | `[mcp_servers.*]` em `config.toml` | `mcpServers` em `settings.json` | `.cursor/mcp.json` (`mcpServers`) |
+
+---
+
+## Detectar o formato de origem e destino
+
+Se o usuário não disser as duas pontas explicitamente, infira-as por estas impressões digitais:
+
+- **Deep Agents** — referências explícitas a `write_file`, `edit_file`, `execute`,
+  `write_todos`, `task`; `.deepagents/`; seções "Contexto de Execução"/"Plano de Execução".
+- **Codex** — `apply_patch`, ferramenta `shell`, `~/.codex/skills` / `.codex/`, `config.toml`,
+  `AGENTS.md`; frontmatter limitado a `name`/`description`/`license`/`allowed-tools`/`metadata`.
+- **Qwen Code** — `allowedTools:` (chave camelCase) com nomes de ferramentas snake_case,
+  `.qwen/`, `QWEN.md`, `{{args}}` em comandos.
+- **Cursor** — `.cursor/skills` / `.cursor/rules/*.mdc`, frontmatter com `globs`/`alwaysApply`
+  (isso é uma Rule, não uma Skill).
+- **Claude Code** — instruções em linguagem natural sem nomes de ferramentas explícitos,
+  `CLAUDE.md`, `.claude/`, `$ARGUMENTS`/`$1`; muitas vezes **sem frontmatter algum**.
+
+---
+
+## Dois níveis de conversão (tiers)
+
+O esforço depende do par:
+
+- **Tier A — remapeamento leve** (Claude Code ↔ Codex / Qwen / Cursor). Os quatro são formatos
+  `SKILL.md` em *linguagem natural* com estrutura quase idêntica. A conversão é basicamente
+  remapear frontmatter + caminhos/arquivo de memória; a prosa das instruções permanece a mesma.
+  Veja o **Procedimento Tier A** abaixo.
+- **Tier B — tradução pesada** (Claude Code ↔ Deep Agents). O Deep Agents usa ferramentas
+  *tipadas e explícitas*, então "crie o arquivo" implícito vira `write_file` explícito, etc.
+  É o procedimento completo T1–T8, documentado a partir de **Contexto: Por que a conversão é
+  necessária**.
+
+> Convertendo entre dois formatos não-Claude (ex.: Codex → Cursor)? Use o Claude Code como hub
+> neutro: origem → Claude Code → destino. Na prática, para pares Tier A dá para remapear direto
+> usando a matriz.
+
+---
+
+## Procedimento Tier A (SKILL.md ↔ SKILL.md: Codex, Qwen Code, Cursor)
+
+Esses alvos executam skills em linguagem natural quase igual ao Claude Code, então o conteúdo
+de domínio e a prosa dos passos são preservados na íntegra. Só o *envelope* muda.
+
+1. **Leia a skill de origem** e detecte origem + destino (veja as impressões digitais acima).
+2. **Frontmatter:**
+   - Garanta um `name` em **hyphen-case** (`^[a-z0-9-]+$`, sem hífen no início/fim, sem `--`,
+     ≤64 chars). Skills do Claude Code costumam *não ter frontmatter* — derive o nome da pasta
+     ou do título `# Skill:`.
+   - Garanta uma `description` (≤1024 chars) que diga **o que faz e quando usar** (os alvos a
+     usam para auto-invocação).
+   - Remapeie os campos opcionais conforme a matriz:
+     - `allowed-tools` do Claude ⇄ `allowed-tools` do Codex (mesma chave) ⇄ `allowedTools` do
+       Qwen (chave camelCase, **nomes de ferramentas em snake_case**). Skills do Cursor não
+       usam allow-list — remova.
+     - Mantenha `metadata` onde houver suporte (Claude/Codex/Cursor); adicione um carimbo
+       `converted-from`/`converter-version`.
+3. **Remapeamento do corpo** (leve — preserve todo o conhecimento de domínio, código, tabelas):
+   - Arquivo de memória/contexto: `CLAUDE.md` → o do alvo (`AGENTS.md` p/ Codex, `QWEN.md` p/
+     Qwen, `AGENTS.md`/Rules p/ Cursor) e vice-versa.
+   - Referências de caminho: `.claude/` → dir de skills/config do alvo.
+   - Config MCP: remapeie caminho **e formato** conforme a matriz (`.mcp.json` JSON →
+     `config.toml [mcp_servers]` p/ Codex; → `settings.json mcpServers` p/ Qwen; →
+     `.cursor/mcp.json` p/ Cursor).
+4. **Sinalize recursos não portáveis explicitamente** (nunca remova em silêncio — deixe uma nota):
+   - Sub-agentes/`Task` → **o Cursor não tem sub-agentes a nível de skill**; Codex/Qwen mantêm `task`.
+   - Hooks do Claude Code (`settings.json`) → sem equivalente em skill; documente como passos manuais/CI.
+   - Extended thinking → depende do modelo; remova config específica de ferramenta, mantenha a intenção.
+5. **Valide** com `scripts/validate-conversion.sh --target <codex|cursor|qwen> <dir>`
+   (e, para Codex, o `skill-creator/scripts/quick_validate.py` que vem com a CLI).
+6. **Salve** em `<nome>/SKILL.md` no dir de skills do alvo (veja a matriz).
+
+### Especificidades do Codex (verificadas no Codex CLI 0.98.0)
+
+- O **allow-list do frontmatter é estrito**: só `name`, `description`, `license`,
+  `allowed-tools`, `metadata`. Qualquer outra chave de topo falha no `quick_validate.py`.
+- A `description` **não pode conter `<` nem `>`** — reescreva frases como "quando A > B" para
+  "quando A é maior que B". É a quebra Claude → Codex mais comum.
+- O sidecar opcional `agents/openai.yaml` fornece metadados de UI
+  (`interface.display_name`, `short_description`, ícones). Gere-o apenas se o usuário quiser
+  um rótulo/ícone customizado.
+- Subdiretórios opcionais `scripts/`, `references/`, `assets/` são copiados como estão.
+- Veja `examples/claude-code-sample/SKILL.md` → `examples/codex-output/SKILL.md` para um
+  before/after completo.
+
+---
+
+# Tier B — Claude Code ↔ Deep Agents (tradução pesada)
+
+Tudo daqui em diante é o caminho do **Deep Agents**: a tradução de ferramentas implícitas ↔
+explícitas (T1–T8). Para Codex, Qwen Code e Cursor, use o **Procedimento Tier A** acima — esses
+alvos não precisam desse nível de reescrita.
 
 ## Contexto: Por que a conversão é necessária
 
@@ -1288,13 +1422,18 @@ As seções 7–11 variam conforme a skill. O importante é que TODAS as seçõe
 
 ## Regras de Ouro
 
-1. **Nunca perder conteúdo.** A skill convertida tem tamanho ≥ original.
-2. **Nunca assumir implícitos.** O Deep Agents CLI precisa de instruções explícitas de qual tool usar.
-3. **Sempre começar com `write_todos`.** O plano é o alicerce de toda execução no Deep Agents.
-4. **Testar depois de cada `write_file`.** O padrão cria → testa → próximo é inquebrável.
-5. **Usar `task` para paralelismo.** Se a skill processa N itens, N sub-agents.
-6. **Preservar todo conhecimento de domínio.** Tabelas, regex, fórmulas, templates — tudo.
-7. **Capturar comandos inline.** Comandos entre crases dentro de frases também precisam de conversão.
-8. **Tratar env vars explicitamente.** Nunca assumir que variáveis estão disponíveis — verificar ou documentar.
-9. **Tornar condicionais executáveis.** Verificações de plataforma viram blocos shell `case`/`if`, não prosa.
-10. **Validar com o checklist.** Rodar a validação baseada em grep antes de salvar.
+**Universais (todo alvo):**
+
+1. **Preservar todo conhecimento de domínio.** Tabelas, regex, fórmulas, código, templates — tudo. A skill convertida tem conteúdo técnico ≥ o original.
+2. **Escolher o tier certo.** Codex / Qwen / Cursor → Tier A (remap leve). Deep Agents → Tier B (T1–T8).
+3. **Remapear o envelope, não o significado.** Frontmatter, caminhos, arquivo de memória, config MCP — conforme a matriz entre formatos.
+4. **Respeitar as regras de frontmatter de cada alvo.** `name` hyphen-case ≤64; `description` ≤1024; para Codex, sem `<`/`>` na description e só as cinco chaves permitidas.
+5. **Sinalizar recursos não portáveis — nunca remover em silêncio.** Sub-agentes no Cursor, hooks, extended thinking: deixe uma nota.
+6. **Validar antes de salvar.** Rodar `scripts/validate-conversion.sh --target <alvo>` (e o `quick_validate.py` do Codex para Codex).
+
+**Adições do Tier B (Deep Agents):**
+
+7. **Nunca assumir implícitos.** O Deep Agents precisa de instruções explícitas de qual tool usar.
+8. **Sempre começar com `write_todos`** e **testar depois de cada `write_file`** (cria → testa → próximo).
+9. **Usar `task` para paralelismo**, tratar **env vars explicitamente** e tornar **condicionais executáveis** (`case`/`if`).
+10. **Capturar comandos inline.** Comandos entre crases dentro de frases também precisam de conversão.

--- a/examples/codex-output/SKILL.md
+++ b/examples/codex-output/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: python-fastapi-todo-app
+description: "Creates a simple Todo REST API with FastAPI, SQLite, and basic CRUD operations. Use when the user asks to create a todo app, task manager API, or a simple Python REST API with create/read/update/delete endpoints."
+metadata:
+  converted-from: claude-code
+  converter-version: "2.2"
+  codex-compat: ">=0.98.0"
+---
+
+# Skill: Python FastAPI Todo App
+
+> Creates a simple Todo API with FastAPI, SQLite, and basic CRUD operations.
+
+## When to use
+
+When the user asks to create a todo app, task manager API, or simple REST API with Python.
+
+## Steps
+
+First, make sure Python 3.11+ is installed. On macOS use `brew install python@3.11`, on Linux use `apt-get install python3.11`.
+
+Create the project directory and initialize a virtual environment:
+
+```bash
+mkdir -p todo-api/app
+cd todo-api
+python3 -m venv venv
+source venv/bin/activate
+```
+
+Install the dependencies:
+
+```bash
+pip install fastapi uvicorn sqlalchemy
+```
+
+Create the file `app/database.py`:
+
+```python
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = "sqlite:///./todos.db"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+```
+
+Create the file `app/models.py`:
+
+```python
+from sqlalchemy import Column, Integer, String, Boolean
+from .database import Base
+
+class Todo(Base):
+    __tablename__ = "todos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, index=True)
+    description = Column(String, default="")
+    completed = Column(Boolean, default=False)
+```
+
+Create `app/main.py` with the FastAPI app, including these endpoints:
+
+- `GET /todos` — list all todos
+- `POST /todos` — create a new todo
+- `PUT /todos/{id}` — update a todo
+- `DELETE /todos/{id}` — delete a todo
+
+The app should read `$API_HOST` and `$API_PORT` from the environment for the server bind address.
+
+Add the project conventions to `AGENTS.md` at the root (Codex reads `AGENTS.md` for persistent project context).
+
+Test the API:
+
+```bash
+curl http://localhost:8000/todos
+```
+
+```bash
+curl -X POST http://localhost:8000/todos -H "Content-Type: application/json" -d '{"title": "Buy milk", "completed": false}'
+```
+
+For each endpoint, run a quick smoke test to make sure it returns 200.
+
+## Notes
+
+- Keep it simple, no auth needed
+- Use SQLite so there's no external database dependency
+- Add a `.env` with `API_HOST=0.0.0.0` and `API_PORT=8000`

--- a/scripts/validate-conversion.sh
+++ b/scripts/validate-conversion.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# validate-conversion.sh — validate a converted SKILL.md against a target format.
+#
+# Part of the Universal SKILL.md Converter.
+# Repo: https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter
+#
+# Usage:
+#   scripts/validate-conversion.sh --target <codex|cursor|qwen|deepagents|claude> <path>
+#
+#   <path> may be either a skill directory (containing SKILL.md) or a SKILL.md file.
+#
+# Exit codes: 0 = valid, 1 = validation errors, 2 = usage error.
+#
+# The checks here mirror the rules each target CLI enforces (e.g. Codex's own
+# quick_validate.py: name hyphen-case <=64, description <=1024 and no angle
+# brackets, restricted frontmatter keys). It is intentionally dependency-light
+# (pure bash + grep/sed) so it runs in CI without extra tooling.
+
+set -euo pipefail
+
+TARGET=""
+TARGET_PATH=""
+
+usage() {
+  echo "Usage: $0 --target <codex|cursor|qwen|deepagents|claude> <path-to-skill-dir-or-SKILL.md>" >&2
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target) TARGET="${2:-}"; shift 2 ;;
+    -h|--help) usage ;;
+    *) TARGET_PATH="$1"; shift ;;
+  esac
+done
+
+[ -n "$TARGET" ] || usage
+[ -n "$TARGET_PATH" ] || usage
+
+# Resolve the SKILL.md file from a directory or direct file path.
+if [ -d "$TARGET_PATH" ]; then
+  FILE="$TARGET_PATH/SKILL.md"
+elif [ -f "$TARGET_PATH" ]; then
+  FILE="$TARGET_PATH"
+else
+  echo "ERROR: path not found: $TARGET_PATH" >&2
+  exit 2
+fi
+
+if [ ! -f "$FILE" ]; then
+  echo "ERROR: SKILL.md not found at: $FILE" >&2
+  exit 2
+fi
+
+ERRORS=0
+WARNINGS=0
+
+err()  { echo "  [ERROR] $1";   ERRORS=$((ERRORS + 1)); }
+warn() { echo "  [WARN]  $1";   WARNINGS=$((WARNINGS + 1)); }
+ok()   { echo "  [OK]    $1"; }
+
+echo "=== Validating $FILE (target: $TARGET) ==="
+
+# --- Extract YAML frontmatter (between the first two '---' lines) -------------
+FRONTMATTER=""
+if head -1 "$FILE" | grep -q '^---[[:space:]]*$'; then
+  FRONTMATTER="$(sed -n '2,/^---[[:space:]]*$/p' "$FILE" | sed '$d')"
+fi
+
+# Helper: read a top-level scalar frontmatter field value (strips quotes).
+fm_field() {
+  printf '%s\n' "$FRONTMATTER" \
+    | grep -E "^$1:[[:space:]]*" \
+    | head -1 \
+    | sed -E "s/^$1:[[:space:]]*//; s/^[\"']//; s/[\"' ]*$//"
+}
+
+# --- Common checks: frontmatter required for every SKILL.md target ------------
+needs_frontmatter() {
+  case "$TARGET" in
+    claude) return 1 ;;   # Claude Code skills do not require YAML frontmatter
+    *)       return 0 ;;
+  esac
+}
+
+if needs_frontmatter; then
+  if [ -z "$FRONTMATTER" ]; then
+    err "no YAML frontmatter found (target '$TARGET' requires it)"
+  else
+    ok "YAML frontmatter present"
+    NAME="$(fm_field name)"
+    DESC="$(fm_field description)"
+    [ -n "$NAME" ] || err "frontmatter missing required 'name'"
+    [ -n "$DESC" ] || err "frontmatter missing required 'description'"
+
+    # name rules shared by Codex/Cursor/Qwen skills (hyphen-case, <=64).
+    if [ -n "$NAME" ]; then
+      if ! printf '%s' "$NAME" | grep -qE '^[a-z0-9-]+$'; then
+        err "name '$NAME' must be hyphen-case (lowercase letters, digits, hyphens)"
+      elif printf '%s' "$NAME" | grep -qE '(^-|-$|--)'; then
+        err "name '$NAME' cannot start/end with a hyphen or contain '--'"
+      elif [ "${#NAME}" -gt 64 ]; then
+        err "name is too long (${#NAME} chars, max 64)"
+      else
+        ok "name '$NAME' is well-formed"
+      fi
+    fi
+
+    # description length (<=1024) shared across targets.
+    if [ -n "$DESC" ] && [ "${#DESC}" -gt 1024 ]; then
+      err "description is too long (${#DESC} chars, max 1024)"
+    fi
+  fi
+fi
+
+# --- Target-specific checks ---------------------------------------------------
+case "$TARGET" in
+  codex)
+    # Codex's quick_validate.py forbids '<' and '>' in the description.
+    if [ -n "${DESC:-}" ] && printf '%s' "$DESC" | grep -q '[<>]'; then
+      err "description contains angle brackets (< or >) — Codex rejects these"
+    fi
+    # Codex allows only these frontmatter keys.
+    if [ -n "$FRONTMATTER" ]; then
+      while IFS= read -r key; do
+        [ -n "$key" ] || continue
+        case "$key" in
+          name|description|license|allowed-tools|metadata) ;;
+          *) warn "frontmatter key '$key' is not in Codex's allow-list (name, description, license, allowed-tools, metadata)" ;;
+        esac
+      done < <(printf '%s\n' "$FRONTMATTER" | grep -E '^[A-Za-z0-9_-]+:' | sed -E 's/:.*//')
+    fi
+    # Codex skills live in <name>/SKILL.md; warn on stale Claude/Deep Agents refs.
+    grep -q 'CLAUDE\.md' "$FILE" && warn "stale reference 'CLAUDE.md' (Codex uses AGENTS.md)"
+    grep -q '\.claude/'  "$FILE" && warn "stale reference '.claude/' (Codex uses .codex/ or ~/.codex/skills)"
+    grep -qE '\bwrite_file\b|\bedit_file\b|\bexecute\b tool' "$FILE" && \
+      warn "Deep Agents tool names present — Codex uses implicit shell/apply_patch, not write_file/execute"
+    ;;
+  cursor)
+    grep -q 'CLAUDE\.md' "$FILE" && warn "stale reference 'CLAUDE.md' (Cursor uses AGENTS.md or .cursor/rules)"
+    grep -q '\.claude/'  "$FILE" && warn "stale reference '.claude/' (Cursor reads .claude/skills as legacy but .cursor/skills is canonical)"
+    ;;
+  qwen)
+    grep -q 'CLAUDE\.md' "$FILE" && warn "stale reference 'CLAUDE.md' (Qwen Code uses QWEN.md or AGENTS.md)"
+    grep -q '\.claude/'  "$FILE" && warn "stale reference '.claude/' (Qwen Code uses .qwen/skills)"
+    ;;
+  deepagents)
+    # Deep Agents conversions must be explicit about tools and sections.
+    for section in "Execution Context" "Execution Plan" "Usage with Deep Agents"; do
+      grep -q "$section" "$FILE" || warn "missing recommended Deep Agents section: $section"
+    done
+    grep -q 'CLAUDE\.md' "$FILE" && warn "stale reference 'CLAUDE.md' (Deep Agents uses AGENTS.md)"
+    grep -q '\.claude/'  "$FILE" && warn "stale reference '.claude/' (Deep Agents uses .deepagents/)"
+    ;;
+  claude)
+    # Reverse target: should NOT carry target-specific tool names / frontmatter noise.
+    grep -q 'AGENTS\.md\|QWEN\.md' "$FILE" && warn "reference to AGENTS.md/QWEN.md remains (Claude Code uses CLAUDE.md)"
+    grep -qE '\bwrite_file\b|\bedit_file\b|\bapply_patch\b' "$FILE" && \
+      warn "explicit tool names remain (Claude Code uses implicit file operations)"
+    ;;
+  *)
+    echo "ERROR: unknown target '$TARGET'" >&2
+    exit 2
+    ;;
+esac
+
+echo "=== Result: $ERRORS error(s), $WARNINGS warning(s) ==="
+[ "$ERRORS" -eq 0 ]


### PR DESCRIPTION
## Summary

Expands the converter from **Claude Code ↔ Deep Agents** into a **universal SKILL.md converter** across five ecosystems — Claude Code, Deep Agents CLI, **Codex CLI**, Qwen Code, and Cursor — in any direction. This PR delivers the universal scaffolding plus the **Codex** target end-to-end (PR 1 of a staged series; Cursor and Qwen follow).

### Key insight
All three new targets (Codex/Qwen/Cursor) have adopted a near-identical natural-language `SKILL.md` format, so conversion to them is a **light remap** (frontmatter + paths + MCP config) — **Tier A**. Deep Agents keeps the heavier typed-tool translation — **Tier B** (unchanged).

## What's in this PR

- **`SKILL.en.md` / `SKILL.pt.md`** — cross-format reference matrix, source/target detection, two-tier model, and a Codex specifics section. Existing Deep Agents (T1–T8) content preserved, relabeled Tier B.
- **`examples/codex-output/SKILL.md`** — the FastAPI Todo sample converted to Codex format.
- **`scripts/validate-conversion.sh`** — dependency-light, multi-target conversion validator (Codex rules implemented; others scaffolded). Wired into CI.
- **README / README.pt** — repositioned + formats table + Codex usage method.
- **CHANGELOG** — v2.2.0. **.markdownlint.jsonc** — disable MD060 (matches existing tables).

## Verification (tested locally)

Codex CLI **0.98.0** is installed here, so the format was verified against the real binary, not just docs:

- ✅ `examples/codex-output` passes **Codex's own** `skill-creator/scripts/quick_validate.py` ("Skill is valid!").
- ✅ Passes `scripts/validate-conversion.sh --target codex` (0 errors, 0 warnings).
- ✅ ShellCheck clean (install.sh + new script); `bash -n install.sh` + `--help` OK.
- ✅ markdownlint clean on all linted docs; SKILL frontmatter valid; Deep Agents examples still pass T1–T8 checks.
- ✅ EN/PT header parity (107/107).

> ⚠️ **Doc vs reality:** the installed Codex 0.98.0 discovers skills under `$CODEX_HOME/skills` (`~/.codex/skills`), **not** `.agents/skills/` as some docs state, and enforces a strict 5-key frontmatter allow-list plus a no-`<`/`>`-in-description rule. The skill and validator follow the verified binary behavior.

## Security

No personal/localhost/secret data introduced — diff swept clean; examples use placeholders only.

## Next (separate PRs)
- PR 2: Cursor bidirectional (tested with local `cursor`).
- PR 3: Qwen Code bidirectional (`npx @qwen-code/qwen-code`).
- PR 4: `install.sh --target` for all 5 CLIs + gitleaks secret-scan CI + EN/PT parity check.