### PR TITLE
feat: Cursor CLI bidirectional support (Tier A) [stacked on #6]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -104,6 +104,8 @@ jobs:
           echo "All examples valid"
       - name: Validate Codex example with the conversion validator
         run: bash scripts/validate-conversion.sh --target codex examples/codex-output
+      - name: Validate Cursor example with the conversion validator
+        run: bash scripts/validate-conversion.sh --target cursor examples/cursor-output/python-fastapi-todo-app
 
   installer-syntax:
     name: Validate Installer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Cursor converter** (bidirectional, Tier A): `.cursor/skills/<name>/SKILL.md` with the skill `name` matching its parent folder; frontmatter `name`/`description` + optional `paths`/`disable-model-invocation`/`metadata` (no `allowed-tools`). Documents Cursor's legacy reading of `.claude/skills/`/`.codex/skills/` and flags sub-agents as non-portable.
+- `examples/cursor-output/python-fastapi-todo-app/SKILL.md` — FastAPI Todo sample converted to Cursor format (folder named to match `name`).
+- `validate-conversion.sh`: Cursor target now checks `name` == parent folder and warns on `allowed-tools`. CI validates the Cursor example.
+
 ## [2.2.0] - 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -197,6 +197,26 @@ scripts/validate-conversion.sh --target codex ~/.codex/skills/my-skill
 python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py ~/.codex/skills/my-skill
 ```
 
+### Method 2c — Convert Claude Code → Cursor (Tier A)
+
+```bash
+deepagents -y
+
+> Read ~/.claude/skills/my-skill/SKILL.md and convert it to a Cursor skill.
+> Save as ~/.cursor/skills/my-skill/SKILL.md
+```
+
+Cursor requires the skill `name` to **match its folder name**, drops `allowed-tools`, and
+reads `AGENTS.md` for project context. Validate with:
+
+```bash
+scripts/validate-conversion.sh --target cursor ~/.cursor/skills/my-skill
+```
+
+> **Heads-up:** Cursor also reads `.claude/skills/` natively as a legacy path, so an existing
+> Claude Code skill frequently works in Cursor with no conversion at all — converting just
+> gives you a clean native layout plus `paths`/`disable-model-invocation`.
+
 ### Method 3 — Dry-run / Preview (no save)
 
 ```bash

--- a/README.pt.md
+++ b/README.pt.md
@@ -187,6 +187,26 @@ scripts/validate-conversion.sh --target codex ~/.codex/skills/minha-skill
 python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py ~/.codex/skills/minha-skill
 ```
 
+### Método 2c — Converter Claude Code → Cursor (Tier A)
+
+```bash
+deepagents -y
+
+> Leia ~/.claude/skills/minha-skill/SKILL.md e converta para uma skill do Cursor.
+> Salve como ~/.cursor/skills/minha-skill/SKILL.md
+```
+
+O Cursor exige que o `name` da skill **seja igual ao nome da pasta**, descarta `allowed-tools`
+e lê o `AGENTS.md` para contexto do projeto. Valide com:
+
+```bash
+scripts/validate-conversion.sh --target cursor ~/.cursor/skills/minha-skill
+```
+
+> **Atenção:** o Cursor também lê `.claude/skills/` nativamente como caminho legado, então uma
+> skill existente do Claude Code frequentemente funciona no Cursor sem conversão alguma — a
+> conversão só te dá um layout nativo limpo com `paths`/`disable-model-invocation`.
+
 ### Método 3 — Dry-run / Preview (sem salvar)
 
 ```bash

--- a/SKILL.en.md
+++ b/SKILL.en.md
@@ -152,6 +152,26 @@ content and step prose are preserved verbatim. Only the *envelope* changes.
 - See `examples/claude-code-sample/SKILL.md` → `examples/codex-output/SKILL.md` for a full
   before/after.
 
+### Cursor specifics (verified against Cursor docs)
+
+- Skill `name` **must match its parent folder name** exactly (lowercase letters, digits,
+  hyphens). So the skill lives at `.cursor/skills/<name>/SKILL.md` where `<name>` equals the
+  frontmatter `name`.
+- Frontmatter: required `name`, `description`; optional `paths` (glob visibility),
+  `disable-model-invocation` (true ⇒ slash-command only), `metadata`. **No `allowed-tools`** —
+  drop it on the way in.
+- Cursor reads `.claude/skills/`, `.codex/skills/`, `~/.claude/skills/`, `~/.codex/skills/`
+  as **legacy paths**, so a Claude Code skill often loads in Cursor with *no conversion at
+  all*. Converting to a native `.cursor/skills/` layout is still cleaner and lets you use
+  `paths`/`disable-model-invocation`.
+- **Sub-agents are non-portable**: Cursor has no skill-level `task`/sub-agent. If the source
+  skill fans out work to sub-agents, leave a note that the steps run sequentially in Cursor.
+- Memory/context: `CLAUDE.md` → `AGENTS.md` (Cursor reads it) or a `.cursor/rules/*.mdc`
+  Always-rule.
+- See `examples/claude-code-sample/SKILL.md` →
+  `examples/cursor-output/python-fastapi-todo-app/SKILL.md` for a full before/after (note the
+  folder named to match `name`).
+
 ---
 
 # Tier B — Claude Code ↔ Deep Agents (heavy translation)

--- a/SKILL.pt.md
+++ b/SKILL.pt.md
@@ -154,6 +154,27 @@ de domínio e a prosa dos passos são preservados na íntegra. Só o *envelope* 
 - Veja `examples/claude-code-sample/SKILL.md` → `examples/codex-output/SKILL.md` para um
   before/after completo.
 
+### Especificidades do Cursor (verificadas na doc do Cursor)
+
+- O `name` da skill **precisa ser igual ao nome da pasta pai** (minúsculas, dígitos, hífens).
+  Ou seja, a skill fica em `.cursor/skills/<name>/SKILL.md` onde `<name>` é igual ao `name` do
+  frontmatter.
+- Frontmatter: obrigatórios `name`, `description`; opcionais `paths` (visibilidade por glob),
+  `disable-model-invocation` (true ⇒ só slash-command), `metadata`. **Sem `allowed-tools`** —
+  remova na entrada.
+- O Cursor lê `.claude/skills/`, `.codex/skills/`, `~/.claude/skills/`, `~/.codex/skills/`
+  como **caminhos legados**, então uma skill do Claude Code muitas vezes carrega no Cursor *sem
+  conversão alguma*. Converter para o layout nativo `.cursor/skills/` ainda é mais limpo e
+  permite usar `paths`/`disable-model-invocation`.
+- **Sub-agentes não são portáveis**: o Cursor não tem `task`/sub-agente a nível de skill. Se a
+  skill de origem distribui trabalho para sub-agentes, deixe uma nota de que os passos rodam
+  sequencialmente no Cursor.
+- Memória/contexto: `CLAUDE.md` → `AGENTS.md` (o Cursor lê) ou uma regra Always em
+  `.cursor/rules/*.mdc`.
+- Veja `examples/claude-code-sample/SKILL.md` →
+  `examples/cursor-output/python-fastapi-todo-app/SKILL.md` para um before/after completo
+  (note a pasta nomeada para bater com o `name`).
+
 ---
 
 # Tier B — Claude Code ↔ Deep Agents (tradução pesada)

--- a/examples/cursor-output/python-fastapi-todo-app/SKILL.md
+++ b/examples/cursor-output/python-fastapi-todo-app/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: python-fastapi-todo-app
+description: "Creates a simple Todo REST API with FastAPI, SQLite, and basic CRUD operations. Use when the user asks to create a todo app, task manager API, or a simple Python REST API with create/read/update/delete endpoints."
+metadata:
+  converted-from: claude-code
+  converter-version: "2.2"
+---
+
+# Skill: Python FastAPI Todo App
+
+> Creates a simple Todo API with FastAPI, SQLite, and basic CRUD operations.
+
+## When to use
+
+When the user asks to create a todo app, task manager API, or simple REST API with Python.
+
+## Steps
+
+First, make sure Python 3.11+ is installed. On macOS use `brew install python@3.11`, on Linux use `apt-get install python3.11`.
+
+Create the project directory and initialize a virtual environment:
+
+```bash
+mkdir -p todo-api/app
+cd todo-api
+python3 -m venv venv
+source venv/bin/activate
+```
+
+Install the dependencies:
+
+```bash
+pip install fastapi uvicorn sqlalchemy
+```
+
+Create the file `app/database.py`:
+
+```python
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = "sqlite:///./todos.db"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+```
+
+Create the file `app/models.py`:
+
+```python
+from sqlalchemy import Column, Integer, String, Boolean
+from .database import Base
+
+class Todo(Base):
+    __tablename__ = "todos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, index=True)
+    description = Column(String, default="")
+    completed = Column(Boolean, default=False)
+```
+
+Create `app/main.py` with the FastAPI app, including these endpoints:
+
+- `GET /todos` — list all todos
+- `POST /todos` — create a new todo
+- `PUT /todos/{id}` — update a todo
+- `DELETE /todos/{id}` — delete a todo
+
+The app should read `$API_HOST` and `$API_PORT` from the environment for the server bind address.
+
+Add the project conventions to `AGENTS.md` at the root (Cursor reads `AGENTS.md` and `.cursor/rules/` for persistent project context).
+
+Test the API:
+
+```bash
+curl http://localhost:8000/todos
+```
+
+```bash
+curl -X POST http://localhost:8000/todos -H "Content-Type: application/json" -d '{"title": "Buy milk", "completed": false}'
+```
+
+For each endpoint, run a quick smoke test to make sure it returns 200.
+
+## Notes
+
+- Keep it simple, no auth needed
+- Use SQLite so there's no external database dependency
+- Add a `.env` with `API_HOST=0.0.0.0` and `API_PORT=8000`

--- a/scripts/validate-conversion.sh
+++ b/scripts/validate-conversion.sh
@@ -138,6 +138,17 @@ case "$TARGET" in
       warn "Deep Agents tool names present — Codex uses implicit shell/apply_patch, not write_file/execute"
     ;;
   cursor)
+    # Cursor requires the skill 'name' to match its parent folder name.
+    PARENT="$(basename "$(dirname "$FILE")")"
+    if [ -n "${NAME:-}" ]; then
+      if [ "$NAME" != "$PARENT" ]; then
+        err "Cursor requires 'name' ('$NAME') to match the parent folder name ('$PARENT')"
+      else
+        ok "name matches parent folder ('$PARENT')"
+      fi
+    fi
+    printf '%s\n' "$FRONTMATTER" | grep -qE '^allowed-tools:' && \
+      warn "'allowed-tools' is not used by Cursor skills — safe to drop"
     grep -q 'CLAUDE\.md' "$FILE" && warn "stale reference 'CLAUDE.md' (Cursor uses AGENTS.md or .cursor/rules)"
     grep -q '\.claude/'  "$FILE" && warn "stale reference '.claude/' (Cursor reads .claude/skills as legacy but .cursor/skills is canonical)"
     ;;


### PR DESCRIPTION
## Summary

Adds the **Cursor** target to the universal converter (Tier A — light remap). **Stacked on #6** (base = `feat/codex-converter`); GitHub will retarget to `main` once #6 merges.

## What's in this PR

- **`SKILL.en.md` / `SKILL.pt.md`** — "Cursor specifics" subsection: skill `name` must match its parent folder; frontmatter `name`/`description` + optional `paths`/`disable-model-invocation`/`metadata` (**no `allowed-tools`**); Cursor reads `.claude/skills/`/`.codex/skills/` as legacy (often **no conversion needed**); **sub-agents flagged non-portable**.
- **`examples/cursor-output/python-fastapi-todo-app/SKILL.md`** — FastAPI Todo converted to a native Cursor skill (folder named to match `name`).
- **`scripts/validate-conversion.sh`** — Cursor target now enforces `name` == parent folder and warns on `allowed-tools`.
- CI validates the Cursor example; README/README.pt Cursor method; CHANGELOG.

## Verification

- ✅ Format verified against **official Cursor docs** (`cursor.com/docs/skills`): location, required/optional frontmatter, name==folder rule, legacy paths, subdirs.
- ✅ Cursor example passes `validate-conversion.sh --target cursor` (0/0).
- ✅ **Negative test**: a name/folder mismatch + stray `allowed-tools` is correctly caught (1 error, 1 warning, exit 1).
- ✅ ShellCheck clean, markdownlint clean, EN/PT parity 108/108, security sweep clean.

> ⚠️ **Honest limitation:** unlike Codex (tested against the real 0.98.0 binary), the local `cursor` is a broken wrapper and there is no `cursor-agent` CLI here, so **live skill discovery in Cursor was not testable on this machine**. Format correctness is verified against the docs and the validator, not a running Cursor instance. If you have a working Cursor, dropping `examples/cursor-output/python-fastapi-todo-app/` into `.cursor/skills/` and typing `/python-fastapi-todo-app` is the live check.

## Security

No personal/localhost/secret data; placeholders only.