### PR TITLE
feat: Qwen Code bidirectional support (Tier A) [stacked on #7]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -106,6 +106,8 @@ jobs:
         run: bash scripts/validate-conversion.sh --target codex examples/codex-output
       - name: Validate Cursor example with the conversion validator
         run: bash scripts/validate-conversion.sh --target cursor examples/cursor-output/python-fastapi-todo-app
+      - name: Validate Qwen example with the conversion validator
+        run: bash scripts/validate-conversion.sh --target qwen examples/qwen-output/python-fastapi-todo-app
 
   installer-syntax:
     name: Validate Installer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Qwen Code converter** (bidirectional, Tier A), verified against Qwen Code 0.17.0 bundled skills: `.qwen/skills/<name>/SKILL.md`, frontmatter `name`/`description` + optional `allowedTools` (snake_case YAML list), `argument-hint`, `when_to_use`, `paths`, `disable-model-invocation`, `priority`. Key step is the snake_case tool-name remap (`Read`→`read_file`, `Bash`→`run_shell_command`, …). `CLAUDE.md`→`QWEN.md`.
+- `examples/qwen-output/python-fastapi-todo-app/SKILL.md` — FastAPI Todo sample converted to a Qwen Code skill, modeled on Qwen's own bundled skills.
+- `validate-conversion.sh`: Qwen target checks folder==name (convention) and flags Claude-style tool names in `allowedTools`. CI validates the Qwen example.
 - **Cursor converter** (bidirectional, Tier A): `.cursor/skills/<name>/SKILL.md` with the skill `name` matching its parent folder; frontmatter `name`/`description` + optional `paths`/`disable-model-invocation`/`metadata` (no `allowed-tools`). Documents Cursor's legacy reading of `.claude/skills/`/`.codex/skills/` and flags sub-agents as non-portable.
 - `examples/cursor-output/python-fastapi-todo-app/SKILL.md` — FastAPI Todo sample converted to Cursor format (folder named to match `name`).
 - `validate-conversion.sh`: Cursor target now checks `name` == parent folder and warns on `allowed-tools`. CI validates the Cursor example.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,23 @@ scripts/validate-conversion.sh --target cursor ~/.cursor/skills/my-skill
 > Claude Code skill frequently works in Cursor with no conversion at all — converting just
 > gives you a clean native layout plus `paths`/`disable-model-invocation`.
 
+### Method 2d — Convert Claude Code → Qwen Code (Tier A)
+
+```bash
+deepagents -y
+
+> Read ~/.claude/skills/my-skill/SKILL.md and convert it to a Qwen Code skill.
+> Save as ~/.qwen/skills/my-skill/SKILL.md
+```
+
+The key step is the **tool-name remap**: Claude `allowed-tools: Read, Write, Edit, Bash`
+becomes Qwen `allowedTools: [read_file, write_file, edit, run_shell_command]` (snake_case YAML
+list). `CLAUDE.md` → `QWEN.md`. Validate with:
+
+```bash
+scripts/validate-conversion.sh --target qwen ~/.qwen/skills/my-skill
+```
+
 ### Method 3 — Dry-run / Preview (no save)
 
 ```bash

--- a/README.pt.md
+++ b/README.pt.md
@@ -207,6 +207,23 @@ scripts/validate-conversion.sh --target cursor ~/.cursor/skills/minha-skill
 > skill existente do Claude Code frequentemente funciona no Cursor sem conversão alguma — a
 > conversão só te dá um layout nativo limpo com `paths`/`disable-model-invocation`.
 
+### Método 2d — Converter Claude Code → Qwen Code (Tier A)
+
+```bash
+deepagents -y
+
+> Leia ~/.claude/skills/minha-skill/SKILL.md e converta para uma skill do Qwen Code.
+> Salve como ~/.qwen/skills/minha-skill/SKILL.md
+```
+
+O passo-chave é o **remap de nomes de ferramentas**: `allowed-tools: Read, Write, Edit, Bash`
+do Claude vira `allowedTools: [read_file, write_file, edit, run_shell_command]` do Qwen (lista
+YAML snake_case). `CLAUDE.md` → `QWEN.md`. Valide com:
+
+```bash
+scripts/validate-conversion.sh --target qwen ~/.qwen/skills/minha-skill
+```
+
 ### Método 3 — Dry-run / Preview (sem salvar)
 
 ```bash

--- a/SKILL.en.md
+++ b/SKILL.en.md
@@ -172,6 +172,23 @@ content and step prose are preserved verbatim. Only the *envelope* changes.
   `examples/cursor-output/python-fastapi-todo-app/SKILL.md` for a full before/after (note the
   folder named to match `name`).
 
+### Qwen Code specifics (verified against Qwen Code 0.17.0 bundled skills)
+
+- Frontmatter: required `name`, `description`; optional `allowedTools` (a YAML **list**, with
+  **snake_case** tool names), `argument-hint`, `when_to_use`, `paths`,
+  `disable-model-invocation`, `priority`. Keep frontmatter minimal — model it on Qwen's own
+  bundled skills (`qc-helper`, `review`).
+- **Tool-name remap is the key step.** Claude `allowed-tools: Read, Write, Edit, Bash` →
+  Qwen `allowedTools: [read_file, write_file, edit, run_shell_command]` (also `grep_search`,
+  `glob`, `read_many_files`, `task`). Snake_case list, not a comma string.
+- The skill folder is named to match `name` (Qwen convention; its bundled skills all follow it).
+- Memory/context: `CLAUDE.md` → `QWEN.md` (Qwen also reads `AGENTS.md`). Imports via
+  `@path/to/file.md` are supported.
+- Slash-command arguments use `{{args}}` (not `$ARGUMENTS`/`$1`); MCP servers go in
+  `~/.qwen/settings.json` under `mcpServers`.
+- See `examples/claude-code-sample/SKILL.md` →
+  `examples/qwen-output/python-fastapi-todo-app/SKILL.md` for a full before/after.
+
 ---
 
 # Tier B — Claude Code ↔ Deep Agents (heavy translation)

--- a/SKILL.pt.md
+++ b/SKILL.pt.md
@@ -175,6 +175,23 @@ de domínio e a prosa dos passos são preservados na íntegra. Só o *envelope* 
   `examples/cursor-output/python-fastapi-todo-app/SKILL.md` para um before/after completo
   (note a pasta nomeada para bater com o `name`).
 
+### Especificidades do Qwen Code (verificadas nas skills bundled do Qwen Code 0.17.0)
+
+- Frontmatter: obrigatórios `name`, `description`; opcionais `allowedTools` (uma **lista** YAML
+  com nomes de ferramentas em **snake_case**), `argument-hint`, `when_to_use`, `paths`,
+  `disable-model-invocation`, `priority`. Mantenha o frontmatter mínimo — espelhe nas próprias
+  skills bundled do Qwen (`qc-helper`, `review`).
+- **O remap de nomes de ferramentas é o passo-chave.** `allowed-tools: Read, Write, Edit, Bash`
+  do Claude → `allowedTools: [read_file, write_file, edit, run_shell_command]` do Qwen (também
+  `grep_search`, `glob`, `read_many_files`, `task`). Lista snake_case, não string com vírgulas.
+- A pasta da skill é nomeada igual ao `name` (convenção do Qwen; todas as bundled seguem isso).
+- Memória/contexto: `CLAUDE.md` → `QWEN.md` (o Qwen também lê `AGENTS.md`). Imports via
+  `@caminho/arquivo.md` são suportados.
+- Argumentos de slash-command usam `{{args}}` (não `$ARGUMENTS`/`$1`); servidores MCP vão em
+  `~/.qwen/settings.json` sob `mcpServers`.
+- Veja `examples/claude-code-sample/SKILL.md` →
+  `examples/qwen-output/python-fastapi-todo-app/SKILL.md` para um before/after completo.
+
 ---
 
 # Tier B — Claude Code ↔ Deep Agents (tradução pesada)

--- a/examples/qwen-output/python-fastapi-todo-app/SKILL.md
+++ b/examples/qwen-output/python-fastapi-todo-app/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: python-fastapi-todo-app
+description: Creates a simple Todo REST API with FastAPI, SQLite, and basic CRUD operations. Use when the user asks to create a todo app, task manager API, or a simple Python REST API with create/read/update/delete endpoints.
+allowedTools:
+  - write_file
+  - edit
+  - read_file
+  - run_shell_command
+---
+
+# Skill: Python FastAPI Todo App
+
+> Creates a simple Todo API with FastAPI, SQLite, and basic CRUD operations.
+
+## When to use
+
+When the user asks to create a todo app, task manager API, or simple REST API with Python.
+
+## Steps
+
+First, make sure Python 3.11+ is installed. On macOS use `brew install python@3.11`, on Linux use `apt-get install python3.11`.
+
+Create the project directory and initialize a virtual environment:
+
+```bash
+mkdir -p todo-api/app
+cd todo-api
+python3 -m venv venv
+source venv/bin/activate
+```
+
+Install the dependencies:
+
+```bash
+pip install fastapi uvicorn sqlalchemy
+```
+
+Create the file `app/database.py`:
+
+```python
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = "sqlite:///./todos.db"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+```
+
+Create the file `app/models.py`:
+
+```python
+from sqlalchemy import Column, Integer, String, Boolean
+from .database import Base
+
+class Todo(Base):
+    __tablename__ = "todos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, index=True)
+    description = Column(String, default="")
+    completed = Column(Boolean, default=False)
+```
+
+Create `app/main.py` with the FastAPI app, including these endpoints:
+
+- `GET /todos` — list all todos
+- `POST /todos` — create a new todo
+- `PUT /todos/{id}` — update a todo
+- `DELETE /todos/{id}` — delete a todo
+
+The app should read `$API_HOST` and `$API_PORT` from the environment for the server bind address.
+
+Add the project conventions to `QWEN.md` at the root (Qwen Code reads `QWEN.md`, and also `AGENTS.md`, for persistent project context).
+
+Test the API:
+
+```bash
+curl http://localhost:8000/todos
+```
+
+```bash
+curl -X POST http://localhost:8000/todos -H "Content-Type: application/json" -d '{"title": "Buy milk", "completed": false}'
+```
+
+For each endpoint, run a quick smoke test to make sure it returns 200.
+
+## Notes
+
+- Keep it simple, no auth needed
+- Use SQLite so there's no external database dependency
+- Add a `.env` with `API_HOST=0.0.0.0` and `API_PORT=8000`

--- a/scripts/validate-conversion.sh
+++ b/scripts/validate-conversion.sh
@@ -153,6 +153,15 @@ case "$TARGET" in
     grep -q '\.claude/'  "$FILE" && warn "stale reference '.claude/' (Cursor reads .claude/skills as legacy but .cursor/skills is canonical)"
     ;;
   qwen)
+    # Qwen bundled skills live in a folder matching the skill name (convention).
+    PARENT="$(basename "$(dirname "$FILE")")"
+    if [ -n "${NAME:-}" ] && [ "$NAME" != "$PARENT" ]; then
+      warn "Qwen skills conventionally live in a folder matching 'name' ('$NAME' vs folder '$PARENT')"
+    fi
+    # allowedTools must use Qwen's snake_case tool names, not Claude PascalCase.
+    if printf '%s\n' "$FRONTMATTER" | grep -qE '^[[:space:]]*-[[:space:]]*(Read|Write|Edit|Bash|Grep|Glob|Task|WebFetch|WebSearch)[[:space:]]*$'; then
+      warn "allowedTools uses Claude-style names — Qwen uses snake_case (read_file, write_file, edit, run_shell_command, grep_search, glob, task)"
+    fi
     grep -q 'CLAUDE\.md' "$FILE" && warn "stale reference 'CLAUDE.md' (Qwen Code uses QWEN.md or AGENTS.md)"
     grep -q '\.claude/'  "$FILE" && warn "stale reference '.claude/' (Qwen Code uses .qwen/skills)"
     ;;


### PR DESCRIPTION
## Summary

Adds the **Qwen Code** target (Tier A — light remap). **Stacked on #7** (which is stacked on #6). GitHub retargets to `main` as the chain merges.

## What's in this PR

- **`SKILL.en.md` / `SKILL.pt.md`** — "Qwen Code specifics": frontmatter `name`/`description` + optional `allowedTools` (snake_case YAML **list**), `argument-hint`, `when_to_use`, `paths`, `disable-model-invocation`, `priority`. The **key step is the tool-name remap** (`Read`→`read_file`, `Write`→`write_file`, `Edit`→`edit`, `Bash`→`run_shell_command`, `Grep`→`grep_search`, …). `CLAUDE.md`→`QWEN.md`; folder named to match `name`.
- **`examples/qwen-output/python-fastapi-todo-app/SKILL.md`** — FastAPI Todo converted to a Qwen skill.
- **`scripts/validate-conversion.sh`** — Qwen target checks folder==name and flags Claude-style tool names in `allowedTools`.
- CI validates the Qwen example; README/README.pt Qwen method; CHANGELOG.

## Verification

- ✅ Format verified against **Qwen Code 0.17.0 bundled skills** (`qc-helper`, `review`, `new-app`), fetched via `npx @qwen-code/qwen-code` and read directly from the package — the authoritative frontmatter shape and snake_case tool names the running CLI itself uses.
- ✅ Qwen example modeled on those shipped skills → valid by construction; passes `validate-conversion.sh --target qwen` (0/0).
- ✅ **Negative test**: Claude-style tool names + folder/name mismatch are flagged (2 warnings).
- ✅ ShellCheck clean, markdownlint clean, EN/PT parity 109/109, security sweep clean.

> ⚠️ **Limitation:** live skill invocation in Qwen needs an interactive session + model auth, so it wasn't executed here. Correctness is grounded in the CLI's own bundled, CLI-loaded skills, not a running conversation.

## Security

No personal/localhost/secret data; placeholders only.