### PR TITLE
feat: install.sh --target (5 CLIs) + gitleaks secret-scan + EN/PT parity CI [stacked on #8]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,3 +118,48 @@ jobs:
         run: bash -n install.sh
       - name: Check install.sh --help exits cleanly
         run: bash install.sh --help
+      - name: Check install.sh rejects an invalid --target
+        run: |
+          if bash install.sh --target bogus >/dev/null 2>&1; then
+            echo "ERROR: invalid --target was accepted"
+            exit 1
+          fi
+          echo "OK: invalid --target rejected"
+
+  lang-parity:
+    name: EN/PT Parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compare heading counts between EN and PT files
+        run: |
+          ERRORS=0
+          check_pair() {
+            en_count=$(grep -cE '^#{1,6} ' "$1")
+            pt_count=$(grep -cE '^#{1,6} ' "$2")
+            if [ "$en_count" -ne "$pt_count" ]; then
+              echo "  MISMATCH: $1 has $en_count headings, $2 has $pt_count"
+              ERRORS=$((ERRORS + 1))
+            else
+              echo "  OK: $1 / $2 ($en_count headings)"
+            fi
+          }
+          check_pair SKILL.en.md SKILL.pt.md
+          check_pair README.md README.pt.md
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "FAILED: $ERRORS parity mismatch(es)"
+            exit 1
+          fi
+          echo "EN/PT parity OK"
+
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan working tree for secrets with gitleaks
+        run: |
+          VERSION=8.21.2
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          ./gitleaks dir . --no-banner --redact --exit-code 1 --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`install.sh --target <deepagents|claude|codex|qwen|cursor>`** — install the converter skill into any of the five CLIs' skill directories (defaults to Deep Agents). The Deep Agents CLI check is now skipped for other targets, and the verify/quick-start output is target-aware. Injected frontmatter updated to the universal v2.2 description (angle-bracket-free, so it passes Codex's validator).
+- **CI hardening** in `lint.yml`: a **gitleaks secret-scan** job (scans the working tree, fails on any finding) and an **EN/PT parity** job (heading-count check for SKILL and README pairs — closes issue #4). The installer job also asserts an invalid `--target` is rejected.
 - **Qwen Code converter** (bidirectional, Tier A), verified against Qwen Code 0.17.0 bundled skills: `.qwen/skills/<name>/SKILL.md`, frontmatter `name`/`description` + optional `allowedTools` (snake_case YAML list), `argument-hint`, `when_to_use`, `paths`, `disable-model-invocation`, `priority`. Key step is the snake_case tool-name remap (`Read`→`read_file`, `Bash`→`run_shell_command`, …). `CLAUDE.md`→`QWEN.md`.
 - `examples/qwen-output/python-fastapi-todo-app/SKILL.md` — FastAPI Todo sample converted to a Qwen Code skill, modeled on Qwen's own bundled skills.
 - `validate-conversion.sh`: Qwen target checks folder==name (convention) and flags Claude-style tool names in `allowedTools`. CI validates the Qwen example.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,17 @@ curl -fsSL .../install.sh | bash -s -- --lang pt
 
 # Install for a specific agent
 curl -fsSL .../install.sh | bash -s -- --agent myagent
+
+# Install the converter skill into another CLI (Deep Agents is the default)
+curl -fsSL .../install.sh | bash -s -- --target codex
+curl -fsSL .../install.sh | bash -s -- --target cursor
+curl -fsSL .../install.sh | bash -s -- --target qwen
+curl -fsSL .../install.sh | bash -s -- --target claude
 ```
+
+`--target` picks the destination skills directory: `~/.deepagents/<agent>/skills`
+(default), `~/.claude/skills`, `$CODEX_HOME/skills`, `~/.qwen/skills`, or `~/.cursor/skills`.
+For Codex it also runs Codex's bundled validator when available.
 
 ### Option B — Clone + install
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -78,7 +78,17 @@ curl -fsSL .../install.sh | bash -s -- --lang pt
 
 # Instalar para um agente específico
 curl -fsSL .../install.sh | bash -s -- --agent meuagente
+
+# Instalar a skill conversora em outra CLI (Deep Agents é o padrão)
+curl -fsSL .../install.sh | bash -s -- --target codex
+curl -fsSL .../install.sh | bash -s -- --target cursor
+curl -fsSL .../install.sh | bash -s -- --target qwen
+curl -fsSL .../install.sh | bash -s -- --target claude
 ```
+
+O `--target` escolhe o diretório de skills de destino: `~/.deepagents/<agente>/skills`
+(padrão), `~/.claude/skills`, `$CODEX_HOME/skills`, `~/.qwen/skills` ou `~/.cursor/skills`.
+Para Codex, ele também roda o validador que vem com o Codex quando disponível.
 
 ### Opção B — Clone + install
 

--- a/install.sh
+++ b/install.sh
@@ -14,9 +14,10 @@
 #     ./install.sh
 #
 # Options:
-#   --agent NAME    Install for a specific agent (default: "agent")
+#   --target NAME   deepagents (default) | claude | codex | qwen | cursor
+#   --agent NAME    Deep Agents agent identifier (only for --target deepagents)
 #   --lang en|pt    Force language (default: auto-detect from $LANG)
-#   --uninstall     Remove the installed skill
+#   --uninstall     Remove the installed skill (honors --target)
 #   --help          Show this help
 #
 # ============================================================================
@@ -26,6 +27,7 @@ set -euo pipefail
 # --- Config ---
 SKILL_NAME="skill-converter"
 AGENT_NAME="agent"
+TARGET="deepagents"
 FORCE_LANG=""
 UNINSTALL=false
 GITHUB_RAW="https://raw.githubusercontent.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter/main"
@@ -73,11 +75,25 @@ print_help() {
     echo "    ./install.sh --agent myagent"
     echo ""
     echo "Options:"
-    echo "  --agent NAME    Agent identifier (default: agent)"
+    echo "  --target NAME   Where to install the converter skill:"
+    echo "                  deepagents (default) | claude | codex | qwen | cursor"
+    echo "  --agent NAME    Deep Agents agent identifier (only for --target deepagents; default: agent)"
     echo "  --lang en|pt    Force language (default: auto-detect from \$LANG)"
-    echo "  --uninstall     Remove the installed skill"
+    echo "  --uninstall     Remove the installed skill (honors --target)"
     echo "  --help          Show this help"
     echo ""
+}
+
+# Resolve the skills directory for the chosen target.
+resolve_skills_dir() {
+    case "$TARGET" in
+        deepagents) echo "$HOME/.deepagents/${AGENT_NAME}/skills" ;;
+        claude)     echo "$HOME/.claude/skills" ;;
+        codex)      echo "${CODEX_HOME:-$HOME/.codex}/skills" ;;
+        qwen)       echo "$HOME/.qwen/skills" ;;
+        cursor)     echo "$HOME/.cursor/skills" ;;
+        *)          echo ""; return 1 ;;
+    esac
 }
 
 detect_language() {
@@ -110,14 +126,16 @@ build_skill_file() {
     local source_file="$1"
     local target_file="$2"
 
-    # Write frontmatter
+    # Write frontmatter (universal; valid for every target's allow-list — the
+    # description has no angle brackets, so it passes Codex's validator too).
     cat > "$target_file" <<'FRONTMATTER'
 ---
 name: skill-converter
-description: "Converts any SKILL.md between Claude Code and Deep Agents CLI formats — preserving 100% of domain knowledge while adapting the execution interface. Supports forward, reverse, dry-run, and batch conversion."
+description: "Universal SKILL.md converter between Claude Code, Deep Agents CLI, Codex CLI, Qwen Code, and Cursor — preserving 100% of domain knowledge while adapting each target's execution interface. Bidirectional, with dry-run preview and batch processing."
 metadata:
-  converter-version: "2.1"
+  converter-version: "2.2"
   deep-agents-compat: ">=0.0.34"
+  codex-compat: ">=0.98.0"
   source-repo: "https://github.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter"
 ---
 
@@ -134,6 +152,17 @@ FRONTMATTER
 # --- Parse arguments ---
 while [[ $# -gt 0 ]]; do
     case $1 in
+        --target)
+            TARGET="$2"
+            case "$TARGET" in
+                deepagents|claude|codex|qwen|cursor) ;;
+                *)
+                    echo -e "${RED}Error: --target must be one of: deepagents, claude, codex, qwen, cursor${NC}"
+                    exit 1
+                    ;;
+            esac
+            shift 2
+            ;;
         --agent)
             AGENT_NAME="$2"
             shift 2
@@ -162,7 +191,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-SKILLS_DIR="$HOME/.deepagents/${AGENT_NAME}/skills"
+SKILLS_DIR="$(resolve_skills_dir)"
 TARGET_DIR="${SKILLS_DIR}/${SKILL_NAME}"
 
 # --- Uninstall ---
@@ -184,16 +213,20 @@ fi
 # =====================
 print_banner
 
-# Check Deep Agents CLI
-if ! command -v deepagents &>/dev/null; then
-    echo -e "${RED}Error: deepagents CLI not found.${NC}"
-    echo ""
-    echo "Install it first:"
-    echo "  pip install deepagents-cli"
-    echo ""
-    exit 1
+echo -e "${CYAN}→${NC} Target: ${BOLD}${TARGET}${NC} (skills dir: ${SKILLS_DIR})"
+
+# Check Deep Agents CLI (only required when installing for Deep Agents).
+if [ "$TARGET" = "deepagents" ]; then
+    if ! command -v deepagents &>/dev/null; then
+        echo -e "${RED}Error: deepagents CLI not found.${NC}"
+        echo ""
+        echo "Install it first:"
+        echo "  pip install deepagents-cli"
+        echo ""
+        exit 1
+    fi
+    echo -e "${GREEN}✓${NC} Deep Agents CLI found: $(deepagents -v 2>&1 | head -1)"
 fi
-echo -e "${GREEN}✓${NC} Deep Agents CLI found: $(deepagents -v 2>&1 | head -1)"
 
 # Detect language
 LANG_CODE=$(detect_language)
@@ -249,11 +282,33 @@ echo -e "${GREEN}✓${NC} Skill installed to: ${BOLD}${TARGET_DIR}/SKILL.md${NC}
 # Verify
 echo ""
 echo -e "${CYAN}Verifying installation...${NC}"
-if deepagents skills info "$SKILL_NAME" --agent "$AGENT_NAME" 2>&1 | grep -qi "skill-converter\|converter"; then
-    echo -e "${GREEN}✓${NC} Skill '${BOLD}${SKILL_NAME}${NC}' is registered and visible in Deep Agents CLI!"
-else
-    echo -e "${GREEN}✓${NC} Skill installed. Run '${BOLD}deepagents skills list${NC}' to verify."
-fi
+case "$TARGET" in
+    deepagents)
+        if deepagents skills info "$SKILL_NAME" --agent "$AGENT_NAME" 2>&1 | grep -qi "skill-converter\|converter"; then
+            echo -e "${GREEN}✓${NC} Skill '${BOLD}${SKILL_NAME}${NC}' is registered and visible in Deep Agents CLI!"
+        else
+            echo -e "${GREEN}✓${NC} Skill installed. Run '${BOLD}deepagents skills list${NC}' to verify."
+        fi
+        ;;
+    codex)
+        echo -e "${GREEN}✓${NC} Skill installed for Codex. It is discovered from \$CODEX_HOME/skills on next run."
+        QV="${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-creator/scripts/quick_validate.py"
+        if [ -f "$QV" ] && command -v python3 &>/dev/null; then
+            if python3 "$QV" "$TARGET_DIR" 2>/dev/null; then
+                echo -e "${GREEN}✓${NC} Passed Codex's bundled skill validator."
+            fi
+        fi
+        ;;
+    claude)
+        echo -e "${GREEN}✓${NC} Skill installed for Claude Code (~/.claude/skills). Restart your session to pick it up."
+        ;;
+    qwen)
+        echo -e "${GREEN}✓${NC} Skill installed for Qwen Code. Use '/skills' in the Qwen Code session to see it."
+        ;;
+    cursor)
+        echo -e "${GREEN}✓${NC} Skill installed for Cursor (~/.cursor/skills). Type '/${SKILL_NAME}' in Agent chat."
+        ;;
+esac
 
 # --- Anonymous install counter (no personal data collected) ---
 curl -fsSL "https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fandersonamaral2%2FClaude-Code-to-Deep-Agents-Skills-Converter%2Finstall&count_bg=%2379C83D&title_bg=%23555555&icon=&emoji=&title=installs&edge_flat=false" -o /dev/null 2>/dev/null || true
@@ -263,15 +318,20 @@ echo ""
 echo -e "${GREEN}${BOLD}Installation complete!${NC}"
 echo ""
 echo -e "${BOLD}Quick start:${NC}"
-echo "  deepagents -y"
-echo "  > Convert this Claude Code skill to Deep Agents: <paste or path>"
-echo ""
-echo -e "${BOLD}Or non-interactive:${NC}"
-echo "  deepagents -y -n \"Convert the Claude Code skill at ./my-skill/SKILL.md to Deep Agents format\""
+if [ "$TARGET" = "deepagents" ]; then
+    echo "  deepagents -y"
+    echo "  > Convert this Claude Code skill to Codex/Qwen/Cursor/Deep Agents: <paste or path>"
+    echo ""
+    echo -e "${BOLD}Or non-interactive:${NC}"
+    echo "  deepagents -y -n \"Convert the skill at ./my-skill/SKILL.md to Codex format\""
+else
+    echo "  Open your ${TARGET} session and ask it to convert a skill, e.g.:"
+    echo "  > Convert ~/.claude/skills/my-skill/SKILL.md to ${TARGET} format and save it"
+fi
 echo ""
 echo -e "${BOLD}Uninstall:${NC}"
 if [ "$MODE" = "local" ]; then
-    echo "  ./install.sh --uninstall"
+    echo "  ./install.sh --target ${TARGET} --uninstall"
 else
     echo "  rm -rf $TARGET_DIR"
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ============================================================================
-# Claude Code ↔ Deep Agents Skill Converter — Installer v2.1
+# Universal SKILL.md Converter — Installer v2.2
 # ============================================================================
 #
 # Works in two modes:
@@ -56,8 +56,8 @@ fi
 print_banner() {
     echo ""
     echo -e "${CYAN}  ╔══════════════════════════════════════════════════════════════╗${NC}"
-    echo -e "${CYAN}  ║${NC}  ${BOLD}Claude Code ↔ Deep Agents Skill Converter${NC}                ${CYAN}║${NC}"
-    echo -e "${CYAN}  ║${NC}  Installer v2.1                                           ${CYAN}║${NC}"
+    echo -e "${CYAN}  ║${NC}  ${BOLD}Universal SKILL.md Converter${NC}                              ${CYAN}║${NC}"
+    echo -e "${CYAN}  ║${NC}  Installer v2.2                                           ${CYAN}║${NC}"
     echo -e "${CYAN}  ╚══════════════════════════════════════════════════════════════╝${NC}"
     echo ""
 }
@@ -126,12 +126,24 @@ build_skill_file() {
     local source_file="$1"
     local target_file="$2"
 
-    # Write frontmatter (universal; valid for every target's allow-list — the
-    # description has no angle brackets, so it passes Codex's validator too).
-    cat > "$target_file" <<'FRONTMATTER'
+    # Write frontmatter. The description has no angle brackets, so it passes
+    # Codex's validator. Qwen Code documents only name/description/allowedTools/
+    # argument-hint/when_to_use/paths/disable-model-invocation/priority — so we
+    # emit a minimal block there (its bundled skills carry no `metadata`).
+    local desc="Universal SKILL.md converter between Claude Code, Deep Agents CLI, Codex CLI, Qwen Code, and Cursor — preserving 100% of domain knowledge while adapting each target's execution interface. Bidirectional, with dry-run preview and batch processing."
+    if [ "$TARGET" = "qwen" ]; then
+        {
+            echo "---"
+            echo "name: skill-converter"
+            echo "description: \"$desc\""
+            echo "---"
+            echo ""
+        } > "$target_file"
+    else
+        cat > "$target_file" <<FRONTMATTER
 ---
 name: skill-converter
-description: "Universal SKILL.md converter between Claude Code, Deep Agents CLI, Codex CLI, Qwen Code, and Cursor — preserving 100% of domain knowledge while adapting each target's execution interface. Bidirectional, with dry-run preview and batch processing."
+description: "$desc"
 metadata:
   converter-version: "2.2"
   deep-agents-compat: ">=0.0.34"
@@ -140,6 +152,7 @@ metadata:
 ---
 
 FRONTMATTER
+    fi
 
     # Append skill content, stripping any existing frontmatter
     if head -1 "$source_file" | grep -q '^---'; then


### PR DESCRIPTION
## Summary

Final PR of the series. Lets the installer place the converter into **any** of the five CLIs, and hardens CI with a **secret scan** (directly serving the "never expose anything" priority) and an **EN/PT parity** check. **Stacked on #8**.

## install.sh

- **`--target <deepagents|claude|codex|qwen|cursor>`** — resolves the right skills dir (`~/.deepagents/<agent>/skills` default, `~/.claude/skills`, `$CODEX_HOME/skills`, `~/.qwen/skills`, `~/.cursor/skills`).
- Deep Agents CLI presence check is **skipped for non-deepagents targets**; verify + quick-start messages are target-aware; for Codex it runs Codex's bundled `quick_validate.py` when present.
- Injected frontmatter updated to the **universal v2.2** description (no angle brackets → passes Codex's validator). `--uninstall` honors `--target`.

## CI (`lint.yml`)

- **`secret-scan`** — gitleaks 8.21.2 scans the working tree, fails on any finding.
- **`lang-parity`** — heading-count parity for `SKILL.en/pt` and `README/README.pt` (**closes #4**).
- Installer job now asserts an invalid `--target` is rejected.

## Verification (tested locally)

- ✅ ShellCheck clean; `install.sh --help` ok; invalid `--target` rejected.
- ✅ **Real install** `--target codex` into a temp `$CODEX_HOME` → produced skill passes **Codex's own** `quick_validate.py`; `--uninstall --target codex` removes it.
- ✅ **gitleaks 8.21.2** `dir .` → "no leaks found" (exit 0) on the repo.
- ✅ markdownlint clean; parity 129/129 (SKILL) and 46/46 (README); all 3 example validators pass.

## Security

Secret-scan now runs on every PR. Diff swept clean; no personal/localhost/secret data.

---

### Series recap (stacked: #6 → #7 → #8 → this)
1. **#6** Universal scaffolding + Codex (Tier A) — *tested vs real Codex 0.98.0*
2. **#7** Cursor (Tier A) — *docs-verified; local Cursor binary not runnable*
3. **#8** Qwen Code (Tier A) — *verified vs Qwen 0.17.0 bundled skills via npx*
4. **this** install `--target` + secret-scan + parity CI

Merge the chain bottom-up (#6 first). Each PR retargets to `main` automatically as the parent merges.