### PR TITLE
ci(security): pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,9 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run ShellCheck on install.sh
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         with:
           scandir: .
           additional_files: install.sh
@@ -25,9 +25,9 @@ jobs:
     name: Markdown Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Lint Markdown files
-        uses: DavidAnson/markdownlint-cli2-action@v19
+        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19
         with:
           globs: |
             README.md
@@ -41,7 +41,7 @@ jobs:
     name: Validate YAML Frontmatter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Check SKILL files have valid frontmatter
         run: |
           ERRORS=0
@@ -71,7 +71,7 @@ jobs:
     name: Validate Converted Examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Check converted examples have T1-T8 sections
         run: |
           ERRORS=0
@@ -113,7 +113,7 @@ jobs:
     name: Validate Installer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Check install.sh syntax
         run: bash -n install.sh
       - name: Check install.sh --help exits cleanly
@@ -130,7 +130,7 @@ jobs:
     name: EN/PT Parity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Compare heading counts between EN and PT files
         run: |
           ERRORS=0
@@ -156,7 +156,7 @@ jobs:
     name: Secret Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Scan working tree for secrets with gitleaks
         run: |
           VERSION=8.21.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
           echo "Extracted changelog for $VERSION"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           name: ${{ steps.version.outputs.VERSION }}
           body_path: release_notes.md


### PR DESCRIPTION
Supply-chain hardening — pins every `uses:` to a full commit SHA with a `# version` comment.

- **`ludeeus/action-shellcheck@master` → `@00cae50…` (v2.0.0)** — the key fix: `master` is a moving branch that ran whatever was pushed to it.
- `DavidAnson/markdownlint-cli2-action@v19` → `@05f3221…`
- `softprops/action-gh-release@v2` → `@3bb1273…` (has `contents: write`)
- `actions/checkout@v4` → `@34e1148…` (all 8 usages)

Prevents a moved tag/branch from silently running new or compromised action code in CI; satisfies OpenSSF Scorecard's pinned-dependencies check. Dependabot still bumps SHA-pinned actions via the version comment. CI itself verifies the SHAs resolve (checkout/shellcheck would fail otherwise).