### PR TITLE
docs: bilingual FAQ to pre-empt common questions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,8 @@ jobs:
             CHANGELOG.md
             SECURITY.md
             CODE_OF_CONDUCT.md
+            docs/FAQ.md
+            docs/FAQ.pt.md
 
   yaml-frontmatter:
     name: Validate YAML Frontmatter

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 Convert **any** SKILL.md between **Claude Code, Deep Agents CLI, Codex CLI, Qwen Code, and Cursor** — preserving 100% of the domain knowledge while adapting each target's execution interface. Every direction is supported, plus dry-run preview and batch processing.
 
 > **Portugues?** [Leia em Portugues](/README.pt.md)
+>
+> **New here?** The [FAQ](docs/FAQ.md) pre-empts the most common questions (do I even need this, fidelity, per-tool differences).
 
 ## Supported formats
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -7,6 +7,8 @@
 Converte **qualquer** SKILL.md entre **Claude Code, Deep Agents CLI, Codex CLI, Qwen Code e Cursor** — preservando 100% do conhecimento de domínio e adaptando a interface de execução de cada alvo. Todas as direções são suportadas, além de preview dry-run e processamento em lote.
 
 > **English?** [Read in English](/README.md)
+>
+> **Primeira vez aqui?** O [FAQ](docs/FAQ.pt.md) antecipa as perguntas mais comuns (preciso disso, fidelidade, diferenças por ferramenta).
 
 ## Formatos suportados
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,147 @@
+# FAQ — Universal SKILL.md Converter
+
+Common questions about what this tool does, how it converts, and where it's verified.
+Portuguese version: [FAQ.pt.md](FAQ.pt.md).
+
+---
+
+## Do I even need this?
+
+### Cursor already reads `.claude/skills/` — why convert at all?
+
+For **Claude Code → Cursor**, often you don't need to: Cursor reads `.claude/skills/` (and
+`.codex/skills/`) as legacy paths, so an existing skill frequently just works. Converting buys
+you two things: a clean native `.cursor/skills/` layout, and access to Cursor-only frontmatter
+like `paths` and `disable-model-invocation`.
+
+The bigger wins are the directions Cursor does **not** auto-handle — Claude Code ↔ **Codex**
+(strict frontmatter rules), ↔ **Qwen Code** (camelCase `allowedTools` with snake_case tool
+names), and ↔ **Deep Agents** (typed, explicit tools).
+
+### They're all converging on `SKILL.md` — won't this be obsolete soon?
+
+The *file* is converging; the *rules around it* are not — and that's the whole problem. Same
+filename, but:
+
+- Codex forbids `<`/`>` in the description and allows only five frontmatter keys.
+- Qwen wants `allowedTools` in camelCase with snake_case tool names.
+- Cursor requires `name` to match the folder and doesn't use `allowed-tools`.
+- The memory file (`CLAUDE.md` vs `AGENTS.md` vs `QWEN.md`) and MCP config differ per tool.
+
+Until those converge too, "just copy the file" silently breaks. If they fully converge, great —
+this becomes a thin validator, which is still useful.
+
+### Isn't this just find-and-replace? Why a skill / LLM?
+
+For the three natural-language targets it's deliberately close to that — we call it **Tier A**:
+remap frontmatter keys, paths, the memory file, and MCP config. That mechanical part is real,
+and `scripts/validate-conversion.sh` enforces each CLI's rules deterministically in plain bash.
+
+The model matters for the messy bits — deriving a valid `name`/`description`, rewriting a
+description that contains `<`/`>` for Codex, preserving 100% of the domain prose — and for
+**Tier B** (Claude Code ↔ Deep Agents), where implicit "create the file" must become explicit
+`write_file` / `execute` / `task` calls. That part is not regex-able.
+
+---
+
+## Conversion fidelity & correctness
+
+### Did you actually verify converted skills load in each tool?
+
+Partially, and the scope matters. We verified the **formats and validators against the
+installed binaries**:
+
+- **Codex 0.98.0** discovers skills under `$CODEX_HOME/skills` and ships
+  `skill-creator/scripts/quick_validate.py`, which restricts frontmatter to
+  `{name, description, license, allowed-tools, metadata}`, requires `name` to match
+  `^[a-z0-9-]+$` (≤64 chars), and **rejects `<`/`>` in the description** (≤1024 chars). The
+  Codex example passes that validator.
+- **Qwen Code 0.17.0** — the example is modeled on Qwen's own bundled skills (`qc-helper`,
+  `review`), so it is valid by construction.
+
+What we did **not** do is a live end-to-end agent run in every tool (Codex auth was expired
+during testing; Qwen needs an interactive session). So: format-validated and validator-checked,
+not "watched the agent execute it in all four." Live-run evidence will be added over time.
+
+### Does bidirectional / round-trip conversion lose information?
+
+Domain knowledge (code, tables, steps, formulas) is preserved in both directions — that's the
+hard invariant. The *envelope* isn't always loss-free: e.g. Deep Agents → Claude Code drops the
+explicit tool annotations (they're implicit in Claude Code), and a target that lacks a given
+field has nowhere to put it. Those losses are noted, never hidden.
+
+### How does it handle sub-agents, hooks, and extended thinking?
+
+It **flags non-portable features instead of silently dropping them**. Cursor has no skill-level
+sub-agents, so a skill that fans work out to `Task` gets a note that those steps run
+sequentially there; Codex/Qwen keep `task`. Claude Code hooks (`settings.json`) and
+extended-thinking blocks get the same treatment: a visible note rather than a skill that looks
+complete but isn't.
+
+### How does it handle MCP servers?
+
+It remaps both the **path** and the **format**, and preserves the `mcp__server__tool` call
+names unchanged:
+
+- Claude Code `.claude/mcp.json` → Deep Agents `.deepagents/mcp.json` (same JSON schema)
+- → Codex `[mcp_servers.*]` in `config.toml`
+- → Qwen Code `mcpServers` in `settings.json`
+- → Cursor `.cursor/mcp.json`
+
+See **Example 12** in `SKILL.en.md` for a full before/after, including the
+`--trust-project-mcp` note for first-use approval of project-level stdio servers.
+
+---
+
+## Per-tool specifics
+
+### What exactly differs between the targets?
+
+The full mapping lives in the
+[cross-format reference matrix](../SKILL.en.md#cross-format-reference-matrix). Summary:
+
+| Concept | Claude Code | Deep Agents | Codex | Qwen Code | Cursor |
+|---------|-------------|-------------|-------|-----------|--------|
+| Skill dir (user) | `~/.claude/skills/` | `~/.deepagents/agent/skills/` | `~/.codex/skills/` | `~/.qwen/skills/` | `~/.cursor/skills/` |
+| Memory file | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` | `QWEN.md` | `AGENTS.md` / Rules |
+| Tools | implicit | typed (`write_file`…) | implicit (`apply_patch`) | snake_case (`read_file`…) | implicit |
+| `name` rule | hyphen-case | hyphen-case | hyphen-case ≤64 | unicode slug | `name` == folder |
+
+### Why is Deep Agents the "odd one out"?
+
+The other four run natural-language skills (the agent infers when to read/write/run). Deep
+Agents CLI uses typed, explicit tools — `write_file`, `edit_file`, `execute`, `task`,
+`write_todos` — so "create the file X" must be rewritten to "use `write_file` to create X",
+with inline tests after each step. That heavier translation is the **Tier B** path the project
+started with.
+
+---
+
+## Project
+
+### License? Commercial use?
+
+MIT — use, fork, adapt, and ship it.
+
+### Why bilingual (EN/PT)?
+
+The maintainer is Brazilian and wanted the Portuguese-speaking dev community covered too. Docs,
+the skill, and this FAQ all ship in both languages, and an EN/PT parity check runs in CI.
+
+### How do you keep up as these CLIs change their formats?
+
+The format facts are pinned to **specific verified versions** (Codex 0.98.0, Qwen Code 0.17.0)
+and documented as such, and `scripts/validate-conversion.sh` encodes each CLI's real rules so
+drift surfaces as a failing check. When a CLI changes, the matrix and validator are updated
+against the new installed binary — not against possibly-stale docs.
+
+### How do I install and use it?
+
+One-liner (defaults to Deep Agents; use `--target` for another CLI):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter/main/install.sh | bash
+```
+
+Full instructions, all install methods, and usage examples are in the
+[README](../README.md).

--- a/docs/FAQ.pt.md
+++ b/docs/FAQ.pt.md
@@ -1,0 +1,149 @@
+# FAQ — Conversor Universal de SKILL.md
+
+Perguntas comuns sobre o que esta ferramenta faz, como ela converte e onde foi verificada.
+Versão em inglês: [FAQ.md](FAQ.md).
+
+---
+
+## Eu preciso disso mesmo?
+
+### O Cursor já lê `.claude/skills/` — por que converter?
+
+Para **Claude Code → Cursor**, muitas vezes você não precisa: o Cursor lê `.claude/skills/`
+(e `.codex/skills/`) como caminhos legados, então uma skill existente frequentemente já
+funciona. Converter te dá duas coisas: um layout nativo `.cursor/skills/` limpo e acesso ao
+frontmatter exclusivo do Cursor (`paths`, `disable-model-invocation`).
+
+Os ganhos maiores estão nas direções que o Cursor **não** trata sozinho — Claude Code ↔
+**Codex** (regras estritas de frontmatter), ↔ **Qwen Code** (`allowedTools` camelCase com
+nomes de ferramentas snake_case) e ↔ **Deep Agents** (ferramentas tipadas e explícitas).
+
+### Estão todos convergindo para `SKILL.md` — isso não vai ficar obsoleto?
+
+O *arquivo* está convergindo; as *regras em volta dele* não — e esse é todo o problema. Mesmo
+nome de arquivo, mas:
+
+- O Codex proíbe `<`/`>` na description e aceita só cinco chaves de frontmatter.
+- O Qwen quer `allowedTools` em camelCase com nomes de ferramentas snake_case.
+- O Cursor exige que o `name` seja igual à pasta e não usa `allowed-tools`.
+- O arquivo de memória (`CLAUDE.md` vs `AGENTS.md` vs `QWEN.md`) e a config MCP mudam por ferramenta.
+
+Enquanto isso não convergir também, "só copiar o arquivo" quebra silenciosamente. Se convergir
+de vez, ótimo — isto vira um validador enxuto, o que ainda é útil.
+
+### Isso não é só find-and-replace? Por que uma skill / LLM?
+
+Para os três alvos de linguagem natural, é proposital ser próximo disso — chamamos de **Tier
+A**: remapear chaves de frontmatter, caminhos, arquivo de memória e config MCP. Essa parte
+mecânica é real, e o `scripts/validate-conversion.sh` aplica as regras de cada CLI de forma
+determinística em bash puro.
+
+O modelo importa nas partes complicadas — derivar um `name`/`description` válido, reescrever uma
+description que contém `<`/`>` para o Codex, preservar 100% da prosa de domínio — e no **Tier
+B** (Claude Code ↔ Deep Agents), onde o "crie o arquivo" implícito precisa virar chamadas
+explícitas `write_file` / `execute` / `task`. Essa parte não é regex.
+
+---
+
+## Fidelidade e corretude da conversão
+
+### Vocês verificaram de verdade que as skills convertidas carregam em cada ferramenta?
+
+Em parte, e o escopo importa. Verificamos os **formatos e validadores contra os binários
+instalados**:
+
+- **Codex 0.98.0** descobre skills em `$CODEX_HOME/skills` e traz o
+  `skill-creator/scripts/quick_validate.py`, que restringe o frontmatter a
+  `{name, description, license, allowed-tools, metadata}`, exige `name` em `^[a-z0-9-]+$`
+  (≤64 chars) e **rejeita `<`/`>` na description** (≤1024 chars). O exemplo Codex passa nesse validador.
+- **Qwen Code 0.17.0** — o exemplo é modelado nas próprias skills bundled do Qwen (`qc-helper`,
+  `review`), então é válido por construção.
+
+O que **não** fizemos foi rodar um agente ponta-a-ponta ao vivo em cada ferramenta (o token do
+Codex estava expirado durante os testes; o Qwen exige sessão interativa). Ou seja:
+validado-por-formato e checado-no-validador, não "vi o agente executar nas quatro". Evidência de
+execução ao vivo será adicionada com o tempo.
+
+### A conversão bidirecional / ida-e-volta perde informação?
+
+O conhecimento de domínio (código, tabelas, passos, fórmulas) é preservado nas duas direções —
+esse é o invariante rígido. O *envelope* nem sempre é sem perdas: ex., Deep Agents → Claude Code
+remove as anotações explícitas de ferramentas (que são implícitas no Claude Code), e um alvo que
+não tem certo campo não tem onde colocá-lo. Essas perdas são sinalizadas, nunca escondidas.
+
+### Como ele trata sub-agentes, hooks e extended thinking?
+
+Ele **sinaliza recursos não portáveis em vez de removê-los em silêncio**. O Cursor não tem
+sub-agentes a nível de skill, então uma skill que distribui trabalho via `Task` recebe uma nota
+de que esses passos rodam sequencialmente lá; Codex/Qwen mantêm `task`. Hooks do Claude Code
+(`settings.json`) e blocos de extended thinking recebem o mesmo tratamento: uma nota visível em
+vez de uma skill que parece completa mas não é.
+
+### Como ele trata servidores MCP?
+
+Ele remapeia o **caminho** e o **formato**, e preserva os nomes de chamada `mcp__server__tool`
+inalterados:
+
+- Claude Code `.claude/mcp.json` → Deep Agents `.deepagents/mcp.json` (mesmo schema JSON)
+- → Codex `[mcp_servers.*]` em `config.toml`
+- → Qwen Code `mcpServers` em `settings.json`
+- → Cursor `.cursor/mcp.json`
+
+Veja o **Exemplo 12** no `SKILL.pt.md` para um before/after completo, incluindo a nota sobre
+`--trust-project-mcp` para a aprovação de primeiro uso de servidores stdio de projeto.
+
+---
+
+## Especificidades por ferramenta
+
+### O que exatamente difere entre os alvos?
+
+O mapeamento completo está na
+[matriz de referência entre formatos](../SKILL.pt.md#matriz-de-referência-entre-formatos). Resumo:
+
+| Conceito | Claude Code | Deep Agents | Codex | Qwen Code | Cursor |
+|----------|-------------|-------------|-------|-----------|--------|
+| Dir. skills (usuário) | `~/.claude/skills/` | `~/.deepagents/agent/skills/` | `~/.codex/skills/` | `~/.qwen/skills/` | `~/.cursor/skills/` |
+| Arquivo de memória | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` | `QWEN.md` | `AGENTS.md` / Rules |
+| Ferramentas | implícitas | tipadas (`write_file`…) | implícitas (`apply_patch`) | snake_case (`read_file`…) | implícitas |
+| Regra do `name` | hyphen-case | hyphen-case | hyphen-case ≤64 | slug unicode | `name` == pasta |
+
+### Por que o Deep Agents é o "ponto fora da curva"?
+
+Os outros quatro rodam skills em linguagem natural (o agente infere quando ler/escrever/rodar).
+O Deep Agents CLI usa ferramentas tipadas e explícitas — `write_file`, `edit_file`, `execute`,
+`task`, `write_todos` — então "crie o arquivo X" precisa virar "use `write_file` para criar X",
+com testes inline após cada passo. Essa tradução mais pesada é o caminho **Tier B** com que o
+projeto começou.
+
+---
+
+## Projeto
+
+### Licença? Uso comercial?
+
+MIT — use, faça fork, adapte e distribua.
+
+### Por que bilíngue (EN/PT)?
+
+O mantenedor é brasileiro e quis cobrir também a comunidade dev lusófona. A documentação, a
+skill e este FAQ saem nos dois idiomas, e uma checagem de paridade EN/PT roda no CI.
+
+### Como vocês acompanham as mudanças de formato dessas CLIs?
+
+Os fatos de formato são fixados em **versões verificadas específicas** (Codex 0.98.0, Qwen Code
+0.17.0) e documentados assim, e o `scripts/validate-conversion.sh` codifica as regras reais de
+cada CLI, de modo que qualquer divergência aparece como um check falhando. Quando uma CLI muda,
+a matriz e o validador são atualizados contra o novo binário instalado — não contra docs
+possivelmente desatualizadas.
+
+### Como eu instalo e uso?
+
+Uma linha (padrão é Deep Agents; use `--target` para outra CLI):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/andersonamaral2/Claude-Code-to-Deep-Agents-Skills-Converter/main/install.sh | bash
+```
+
+Instruções completas, todos os métodos de instalação e exemplos de uso estão no
+[README](../README.pt.md).


### PR DESCRIPTION
Adds `docs/FAQ.md` + `docs/FAQ.pt.md` (EN/PT mirror) answering the questions the v2.2 announcement is likely to draw — Cursor's legacy `.claude/skills` reading, SKILL.md convergence, find-and-replace vs LLM, the **honest verification scope** (format/validator-checked, not live agent runs in all four), round-trip fidelity, sub-agents/hooks/MCP handling, per-tool differences, and project/license/maintenance questions.

Linked from both READMEs; both FAQ files added to the markdownlint CI globs. markdownlint clean (8 files), FAQ parity 18/18, gitleaks clean, no personal data.